### PR TITLE
[Feature/add_song_select_mode] 게시글 노래 첨부 기능 구현

### DIFF
--- a/app/src/main/java/com/wepli/app/navigation/NavHost.kt
+++ b/app/src/main/java/com/wepli/app/navigation/NavHost.kt
@@ -23,6 +23,7 @@ import com.wepli.community.navigation.navigateToCommunityWrite
 import com.wepli.playlist.navigation.navigateToPlaylistDetail
 import com.wepli.playlist.navigation.playlistDetailGraph
 import com.wepli.search.navigation.SearchScreenMode
+import com.wepli.search.navigation.navigateBackWithSelectedSongs
 import com.wepli.search.navigation.navigateToSearchDetail
 import com.wepli.search.navigation.searchDetailGraph
 import com.wepli.search.navigation.searchMainGraph
@@ -76,7 +77,10 @@ fun NavGraphBuilder.searchGraph(navController: NavController) {
     }
 
     searchDetailGraph(
-        navOnBack = { navController.navigateToBack() }
+        navOnBack = { navController.navigateToBack() },
+        navigateBackWithSelectedSongs = { selectedSongs ->
+            navController.navigateBackWithSelectedSongs(selectedSongs)
+        }
     )
 }
 

--- a/app/src/main/java/com/wepli/app/navigation/NavHost.kt
+++ b/app/src/main/java/com/wepli/app/navigation/NavHost.kt
@@ -22,6 +22,7 @@ import com.wepli.community.navigation.communityWriteGraph
 import com.wepli.community.navigation.navigateToCommunityWrite
 import com.wepli.playlist.navigation.navigateToPlaylistDetail
 import com.wepli.playlist.navigation.playlistDetailGraph
+import com.wepli.search.navigation.SearchScreenMode
 import com.wepli.search.navigation.navigateToSearchDetail
 import com.wepli.search.navigation.searchDetailGraph
 import com.wepli.search.navigation.searchMainGraph
@@ -68,7 +69,10 @@ fun SetUpNavGraph(
 // 검색 Graph
 fun NavGraphBuilder.searchGraph(navController: NavController) {
     searchMainGraph { searchQuery ->
-        navController.navigateToSearchDetail(searchQuery)
+        navController.navigateToSearchDetail(
+            screenMode = SearchScreenMode.NORMAL,
+            searchQuery = searchQuery
+        )
     }
 
     searchDetailGraph(
@@ -87,7 +91,12 @@ fun NavGraphBuilder.communityGraph(navController: NavHostController) {
     )
     communityWriteGraph(
         navOnBack = { navController.navigateToBack() },
-        navOnSearchDetail = { navController.navigateToSearchDetail("") }
+        navOnSearchDetail = {
+            navController.navigateToSearchDetail(
+                screenMode = SearchScreenMode.SELECTABLE,
+                searchQuery = ""
+            )
+        }
     )
 }
 

--- a/core/common/src/main/kotlin/base/BaseMviViewModel.kt
+++ b/core/common/src/main/kotlin/base/BaseMviViewModel.kt
@@ -48,5 +48,9 @@ abstract class BaseMviViewModel<S : UiState, E : SideEffect, I : Intent>(
         return viewModelScope.launch(dispatcher + exceptionHandler, start, block)
     }
 
+    fun processIntent(vararg intents: I) {
+        intents.forEach(::processIntent)
+    }
+
     abstract fun processIntent(intent: I)
 }

--- a/core/common/src/main/kotlin/base/BaseMviViewModel.kt
+++ b/core/common/src/main/kotlin/base/BaseMviViewModel.kt
@@ -26,6 +26,14 @@ abstract class BaseMviViewModel<S : UiState, E : SideEffect, I : Intent>(
         throw throwable
     }
 
+    protected inline fun <STATE : Any> ContainerHost<STATE, *>.updateState(
+        crossinline reducer: STATE.() -> STATE
+    ) {
+        intent {
+            reduce { state.reducer() }
+        }
+    }
+
     fun launch(
         dispatcher: CoroutineDispatcher = Dispatchers.Main.immediate,
         start: CoroutineStart = CoroutineStart.DEFAULT,

--- a/core/common/src/main/kotlin/extensions/compose/ComposableExt.kt
+++ b/core/common/src/main/kotlin/extensions/compose/ComposableExt.kt
@@ -14,16 +14,20 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
+import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.PointerInputChange
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.TextUnit
 import kotlin.math.absoluteValue
@@ -96,4 +100,112 @@ fun Modifier.shimmerEffect(radius: Dp): Modifier = composed {
         ),
         shape = RoundedCornerShape(radius)
     ).onGloballyPositioned { size = it.size }
+}
+
+fun Modifier.topBorder(
+    brush: Brush,
+    height: Float,
+    alpha: Float = 1f,
+) = this.drawWithContent {
+    drawContent()
+    drawLine(
+        brush = brush,
+        start = Offset(0f, 0f),
+        end = Offset(size.width, 0f),
+        strokeWidth = height,
+        alpha = alpha,
+    )
+}
+
+fun Modifier.rightBorder(
+    brush: Brush,
+    width: Float,
+    alpha: Float = 1f,
+) = this.drawWithContent {
+    drawContent()
+    drawLine(
+        brush = brush,
+        start = Offset(size.width, 0f),
+        end = Offset(size.width, size.height),
+        strokeWidth = width,
+        alpha = alpha,
+    )
+}
+
+fun Modifier.bottomBorder(
+    brush: Brush,
+    height: Float,
+    alpha: Float = 1f,
+) = this.drawWithContent {
+    drawContent()
+    drawLine(
+        brush = brush,
+        start = Offset(0f, size.height),
+        end = Offset(size.width, size.height),
+        strokeWidth = height,
+        alpha = alpha,
+    )
+}
+
+fun Modifier.leftBorder(
+    brush: Brush,
+    width: Float,
+    alpha: Float = 1f,
+) = this.drawWithContent {
+    drawContent()
+    drawLine(
+        brush = brush,
+        start = Offset(0f, 0f),
+        end = Offset(0f, size.height),
+        strokeWidth = width,
+        alpha = alpha,
+    )
+}
+
+fun Modifier.topBorderWithRoundedCorners(
+    brush: Brush,
+    height: Dp,
+    cornerRadius: Dp,
+    alpha: Float = 1f,
+): Modifier = this.drawWithContent {
+    val strokeWidth = height.toPx()
+    val radius = cornerRadius.toPx()
+    val path = Path().apply {
+        // 좌측 상단 코너
+        arcTo(
+            rect = Rect(
+                left = 0f,
+                top = strokeWidth / 2,
+                right = 2 * radius,
+                bottom = strokeWidth / 2 + 2 * radius
+            ),
+            startAngleDegrees = 180f, // 호의 시작점 (0도 : 오른쪽, 90도 : 아래쪽)
+            sweepAngleDegrees = 90f, // 호가 그려지는 방향과 각도 (90f이면 시계방향으로 90도 회전하면서 그려짐)
+            forceMoveTo = false
+        )
+1
+        // Draw the top straight line (between the rounded corners)
+        lineTo(size.width - radius, strokeWidth / 2)
+
+        // 오른쪽 상단 코너
+        arcTo(
+            rect = Rect(
+                left = size.width - 2 * radius,
+                top = strokeWidth / 2,
+                right = size.width,
+                bottom = strokeWidth / 2 + 2 * radius
+            ),
+            startAngleDegrees = -90f,
+            sweepAngleDegrees = 90f,
+            forceMoveTo = false
+        )
+    }
+
+    drawContent()
+    drawPath(
+        path = path,
+        brush = brush,
+        style = Stroke(width = strokeWidth),
+        alpha = alpha
+    )
 }

--- a/core/navigator/src/main/java/com/wepli/navigator/extras/Extras.kt
+++ b/core/navigator/src/main/java/com/wepli/navigator/extras/Extras.kt
@@ -1,5 +1,5 @@
 package com.wepli.navigator.extras
 
 object Extras {
-    const val POST_DATA = "POST_DATA"
+    const val SELECTED_SONGS = "SELECTED_SONGS"
 }

--- a/designsystem/src/main/kotlin/custom/SongItem.kt
+++ b/designsystem/src/main/kotlin/custom/SongItem.kt
@@ -21,11 +21,14 @@ import androidx.compose.ui.unit.dp
 import com.wepli.designsystem.R
 import com.wepli.shared.feature.mock.songUiMockData
 import com.wepli.uimodel.music.SongUiData
+import extensions.compose.toPx
 import image.AsyncImageWithPreview
 import theme.WepliTheme
 
 @Composable
 fun SongItem(song: SongUiData) {
+    val imagePixel = 92.dp.toPx()
+
     Column(
         modifier = Modifier.width(92.dp)
     ) {
@@ -34,7 +37,7 @@ fun SongItem(song: SongUiData) {
                 modifier = Modifier
                     .size(92.dp)
                     .clip(RoundedCornerShape(4.dp)),
-                imageUrl = song.coverImg,
+                imageUrl = song.getImageUrl(imagePixel),
                 previewImage = painterResource(id = R.drawable.img_placeholder_album_cover),
                 imageOverrideSize = 92.dp,
             )

--- a/designsystem/src/main/kotlin/custom/SongItem.kt
+++ b/designsystem/src/main/kotlin/custom/SongItem.kt
@@ -1,5 +1,6 @@
 package custom
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -26,11 +27,16 @@ import image.AsyncImageWithPreview
 import theme.WepliTheme
 
 @Composable
-fun SongItem(song: SongUiData) {
+fun SongItem(
+    song: SongUiData,
+    onClick: () -> Unit = {},
+) {
     val imagePixel = 92.dp.toPx()
 
     Column(
-        modifier = Modifier.width(92.dp)
+        modifier = Modifier
+            .clickable { onClick() }
+            .width(92.dp)
     ) {
         Box(modifier = Modifier) {
             AsyncImageWithPreview(

--- a/feature/community/src/main/kotlin/com/wepli/community/navigation/CommunityNavigation.kt
+++ b/feature/community/src/main/kotlin/com/wepli/community/navigation/CommunityNavigation.kt
@@ -11,10 +11,11 @@ import androidx.navigation.navArgument
 import com.wepli.community.detail.CommunityDetailScreen
 import com.wepli.community.detail.CommunityDetailViewModel
 import com.wepli.community.main.CommunityScreen
-import com.wepli.community.write.screen.CommunityWriteScreen
 import com.wepli.community.write.screen.CommunityWriteScreenRoute
+import com.wepli.navigator.extras.Extras
 import com.wepli.navigator.feature.community.CommunityRoute
 import com.wepli.shared.feature.uimodel.community.PostUiData
+import com.wepli.uimodel.music.SongUiData
 import extensions.enterAnimation
 import extensions.parseFromJson
 import extensions.toJsonString
@@ -68,6 +69,8 @@ fun NavGraphBuilder.communityWriteGraph(
     navOnSearchDetail: () -> Unit
 ) {
     composable(CommunityRoute.Write.route) {
-        CommunityWriteScreenRoute(navOnBack, navOnSearchDetail)
+        val selectedSongs: List<SongUiData>? = it.savedStateHandle.remove<List<SongUiData>>(Extras.SELECTED_SONGS)
+
+        CommunityWriteScreenRoute(selectedSongs, navOnBack, navOnSearchDetail)
     }
 }

--- a/feature/community/src/main/kotlin/com/wepli/community/write/mvi/ComunnityWriteMvi.kt
+++ b/feature/community/src/main/kotlin/com/wepli/community/write/mvi/ComunnityWriteMvi.kt
@@ -25,4 +25,5 @@ interface CommunityWriteIntent : Intent {
     data class UpdateContents(val contents: String, val maxLength: Int) : CommunityWriteIntent
     data class ShowMusicSelectBottomSheet(val isVisible: Boolean) : CommunityWriteIntent
     data class UpdateSelectedSongs(val selectedSongs: List<SongUiData>) : CommunityWriteIntent
+    data class RemoveSelectedSongs(val song: SongUiData) : CommunityWriteIntent
 }

--- a/feature/community/src/main/kotlin/com/wepli/community/write/mvi/ComunnityWriteMvi.kt
+++ b/feature/community/src/main/kotlin/com/wepli/community/write/mvi/ComunnityWriteMvi.kt
@@ -24,4 +24,5 @@ interface CommunityWriteIntent : Intent {
     data class UpdateTitle(val title: String, val maxLength: Int) : CommunityWriteIntent
     data class UpdateContents(val contents: String, val maxLength: Int) : CommunityWriteIntent
     data class ShowMusicSelectBottomSheet(val isVisible: Boolean) : CommunityWriteIntent
+    data class UpdateSelectedSongs(val selectedSongs: List<SongUiData>) : CommunityWriteIntent
 }

--- a/feature/community/src/main/kotlin/com/wepli/community/write/screen/CommunityWriteScreen.kt
+++ b/feature/community/src/main/kotlin/com/wepli/community/write/screen/CommunityWriteScreen.kt
@@ -222,7 +222,10 @@ fun SelectedSongLayout(
             contentPadding = PaddingValues(horizontal = 20.dp)
         ) {
             items(selectedSongs) { song ->
-                SongItem(song = song)
+                SongItem(
+                    song = song,
+                    onClick = { sendAction(CommunityWriteIntent.RemoveSelectedSongs(song)) }
+                )
             }
 
             item {

--- a/feature/community/src/main/kotlin/com/wepli/community/write/screen/CommunityWriteScreen.kt
+++ b/feature/community/src/main/kotlin/com/wepli/community/write/screen/CommunityWriteScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -51,11 +52,18 @@ import theme.WepliTheme
 
 @Composable
 fun CommunityWriteScreenRoute(
+    selectedSongs: List<SongUiData>?,
     navOnBack: () -> Unit,
     navOnSearchDetail: () -> Unit
 ) {
     val viewModel: CommunityWriteViewModel = hiltViewModel()
     val state: CommunityWriteUiState by viewModel.collectAsState()
+
+    selectedSongs?.let {
+        LaunchedEffect(it) {
+            viewModel.processIntent(CommunityWriteIntent.UpdateSelectedSongs(selectedSongs))
+        }
+    }
 
     CommunityWriteScreen(
         state = state,

--- a/feature/community/src/main/kotlin/com/wepli/community/write/screen/CommunityWriteScreen.kt
+++ b/feature/community/src/main/kotlin/com/wepli/community/write/screen/CommunityWriteScreen.kt
@@ -41,9 +41,11 @@ import com.wepli.community.write.mvi.CommunityWriteIntent
 import com.wepli.community.write.mvi.CommunityWriteUiState
 import com.wepli.community.write.viewmodel.CommunityWriteViewModel
 import com.wepli.designsystem.R
+import com.wepli.shared.feature.mock.songMockData
 import com.wepli.uimodel.music.SongUiData
 import component.bottomsheet.WepliBottomSheetType
 import component.bottomsheet.WepliBottomSheet
+import compose.MeasuredHeightContainer
 import custom.SongItem
 import org.orbitmvi.orbit.compose.collectAsState
 import textfield.WepliTextField
@@ -214,23 +216,27 @@ fun SelectedSongLayout(
             modifier = Modifier.padding(horizontal = 20.dp)
         )
 
-        LazyRow(
-            state = lazyRowState,
-            modifier = Modifier
-                .fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
-            contentPadding = PaddingValues(horizontal = 20.dp)
+        MeasuredHeightContainer(
+            measured = { SongItem(songMockData[0]) }
         ) {
-            items(selectedSongs) { song ->
-                SongItem(
-                    song = song,
-                    onClick = { sendAction(CommunityWriteIntent.RemoveSelectedSongs(song)) }
-                )
-            }
+            LazyRow(
+                state = lazyRowState,
+                modifier = Modifier
+                    .fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                contentPadding = PaddingValues(horizontal = 20.dp)
+            ) {
+                items(selectedSongs) { song ->
+                    SongItem(
+                        song = song,
+                        onClick = { sendAction(CommunityWriteIntent.RemoveSelectedSongs(song)) }
+                    )
+                }
 
-            item {
-                AddSongButton {
-                    sendAction(CommunityWriteIntent.ShowMusicSelectBottomSheet(true))
+                item {
+                    AddSongButton {
+                        sendAction(CommunityWriteIntent.ShowMusicSelectBottomSheet(true))
+                    }
                 }
             }
         }

--- a/feature/community/src/main/kotlin/com/wepli/community/write/screen/CommunityWriteScreen.kt
+++ b/feature/community/src/main/kotlin/com/wepli/community/write/screen/CommunityWriteScreen.kt
@@ -218,7 +218,7 @@ fun SelectedSongLayout(
             state = lazyRowState,
             modifier = Modifier
                 .fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
             contentPadding = PaddingValues(horizontal = 20.dp)
         ) {
             items(selectedSongs) { song ->

--- a/feature/community/src/main/kotlin/com/wepli/community/write/viewmodel/CommunityWriteViewModel.kt
+++ b/feature/community/src/main/kotlin/com/wepli/community/write/viewmodel/CommunityWriteViewModel.kt
@@ -27,6 +27,9 @@ class CommunityWriteViewModel @Inject constructor() : BaseMviViewModel<Community
             is CommunityWriteIntent.UpdateSelectedSongs -> {
                 handleUpdateSelectedSongs(intent.selectedSongs)
             }
+            is CommunityWriteIntent.RemoveSelectedSongs -> {
+                handleRemoveSelectedSongs(intent.song)
+            }
         }
     }
 
@@ -66,5 +69,7 @@ class CommunityWriteViewModel @Inject constructor() : BaseMviViewModel<Community
                 selectedSongs = (state.selectedSongs + newSelectedSongs).distinct()
             )
         }
+    private fun handleRemoveSelectedSongs(song: SongUiData) {
+        updateState { copy(selectedSongs = selectedSongs - song) }
     }
 }

--- a/feature/community/src/main/kotlin/com/wepli/community/write/viewmodel/CommunityWriteViewModel.kt
+++ b/feature/community/src/main/kotlin/com/wepli/community/write/viewmodel/CommunityWriteViewModel.kt
@@ -4,7 +4,7 @@ import base.BaseMviViewModel
 import com.wepli.community.write.mvi.CommunityWriteEffect
 import com.wepli.community.write.mvi.CommunityWriteIntent
 import com.wepli.community.write.mvi.CommunityWriteUiState
-import com.wepli.shared.feature.mock.songMockData
+import com.wepli.uimodel.music.SongUiData
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
@@ -12,11 +12,6 @@ import javax.inject.Inject
 class CommunityWriteViewModel @Inject constructor() : BaseMviViewModel<CommunityWriteUiState, CommunityWriteEffect, CommunityWriteIntent>(
     initialState = CommunityWriteUiState()
 ) {
-    init {
-        intent {
-            reduce { state.copy(selectedSongs = songMockData.take(10)) }
-        }
-    }
 
     override fun processIntent(intent: CommunityWriteIntent) {
         when (intent) {
@@ -28,6 +23,9 @@ class CommunityWriteViewModel @Inject constructor() : BaseMviViewModel<Community
             }
             is CommunityWriteIntent.ShowMusicSelectBottomSheet -> {
                 handleShowMusicSelectBottomSheet(intent.isVisible)
+            }
+            is CommunityWriteIntent.UpdateSelectedSongs -> {
+                handleUpdateSelectedSongs(intent.selectedSongs)
             }
         }
     }
@@ -58,6 +56,14 @@ class CommunityWriteViewModel @Inject constructor() : BaseMviViewModel<Community
         reduce {
             state.copy(
                 isShowMusicSelectBottomSheet = isVisible
+            )
+        }
+    }
+
+    private fun handleUpdateSelectedSongs(newSelectedSongs: List<SongUiData>) = intent {
+        reduce {
+            state.copy(
+                selectedSongs = (state.selectedSongs + newSelectedSongs).distinct()
             )
         }
     }

--- a/feature/community/src/main/kotlin/com/wepli/community/write/viewmodel/CommunityWriteViewModel.kt
+++ b/feature/community/src/main/kotlin/com/wepli/community/write/viewmodel/CommunityWriteViewModel.kt
@@ -33,42 +33,34 @@ class CommunityWriteViewModel @Inject constructor() : BaseMviViewModel<Community
         }
     }
 
-    private fun handleUpdateTitle(title: String, maxLength: Int) = intent {
-        reduce {
-            state.copy(
-                title = CommunityWriteUiState.FieldState(
-                    text = title,
-                    isLengthExceeded = title.length > maxLength
-                ),
-            )
+    private fun handleUpdateTitle(title: String, maxLength: Int) {
+        val updatedFiledState = CommunityWriteUiState.FieldState(
+            text = title,
+            isLengthExceeded = title.length > maxLength
+        )
+        updateState { copy(title = updatedFiledState) }
+    }
+
+    private fun handleUpdateContents(contents: String, maxLength: Int) {
+        val updatedFiledState = CommunityWriteUiState.FieldState(
+            text = contents,
+            isLengthExceeded = contents.length > maxLength
+        )
+
+        updateState { copy(contents = updatedFiledState) }
+    }
+
+    private fun handleShowMusicSelectBottomSheet(isVisible: Boolean) {
+        updateState { copy(isShowMusicSelectBottomSheet = isVisible) }
+    }
+
+    private fun handleUpdateSelectedSongs(newSelectedSongs: List<SongUiData>) {
+        updateState {
+            val updatedSelectSongs: List<SongUiData> = (selectedSongs + newSelectedSongs).distinct()
+            copy(selectedSongs = updatedSelectSongs)
         }
     }
 
-    private fun handleUpdateContents(contents: String, maxLength: Int) = intent {
-        reduce {
-            state.copy(
-                contents = CommunityWriteUiState.FieldState(
-                    text = contents,
-                    isLengthExceeded = contents.length > maxLength
-                ),
-            )
-        }
-    }
-
-    private fun handleShowMusicSelectBottomSheet(isVisible: Boolean) = intent {
-        reduce {
-            state.copy(
-                isShowMusicSelectBottomSheet = isVisible
-            )
-        }
-    }
-
-    private fun handleUpdateSelectedSongs(newSelectedSongs: List<SongUiData>) = intent {
-        reduce {
-            state.copy(
-                selectedSongs = (state.selectedSongs + newSelectedSongs).distinct()
-            )
-        }
     private fun handleRemoveSelectedSongs(song: SongUiData) {
         updateState { copy(selectedSongs = selectedSongs - song) }
     }

--- a/feature/search/src/main/java/com/wepli/search/detail/mvi/SearchDetailUiState.kt
+++ b/feature/search/src/main/java/com/wepli/search/detail/mvi/SearchDetailUiState.kt
@@ -1,4 +1,4 @@
-package com.wepli.search.detail.state
+package com.wepli.search.detail.mvi
 
 import base.Intent
 import base.SideEffect

--- a/feature/search/src/main/java/com/wepli/search/detail/mvi/SearchDetailUiState.kt
+++ b/feature/search/src/main/java/com/wepli/search/detail/mvi/SearchDetailUiState.kt
@@ -18,5 +18,5 @@ interface SearchDetailEffect : SideEffect {
 interface SearchDetailIntent : Intent {
     data class OnSearchQueryChanged(val query: String) : SearchDetailIntent
     data class RequestSearch(val query: String) : SearchDetailIntent
-    data class SelectSong(val song: SongUiData) : SearchDetailIntent
+    data class OnSongSelected(val song: SongUiData) : SearchDetailIntent
 }

--- a/feature/search/src/main/java/com/wepli/search/detail/mvi/SearchDetailUiState.kt
+++ b/feature/search/src/main/java/com/wepli/search/detail/mvi/SearchDetailUiState.kt
@@ -13,10 +13,12 @@ data class SearchDetailUiState(
 
 interface SearchDetailEffect : SideEffect {
     data class SearchError(val message: String) : SearchDetailEffect
+    data class NavigateBackWithResult(val selectedSongs: List<SongUiData>) : SearchDetailEffect
 }
 
 interface SearchDetailIntent : Intent {
     data class OnSearchQueryChanged(val query: String) : SearchDetailIntent
     data class RequestSearch(val query: String) : SearchDetailIntent
     data class OnSongSelected(val song: SongUiData) : SearchDetailIntent
+    data object OnCompleteSongSelect : SearchDetailIntent
 }

--- a/feature/search/src/main/java/com/wepli/search/detail/mvi/SearchDetailUiState.kt
+++ b/feature/search/src/main/java/com/wepli/search/detail/mvi/SearchDetailUiState.kt
@@ -8,6 +8,7 @@ import com.wepli.uimodel.music.SongUiData
 data class SearchDetailUiState(
     val searchInput: String = "",
     val searchMusicResult: List<SongUiData> = emptyList(),
+    val selectedSongs: LinkedHashSet<SongUiData> = linkedSetOf()
 ) : UiState
 
 interface SearchDetailEffect : SideEffect {
@@ -17,4 +18,5 @@ interface SearchDetailEffect : SideEffect {
 interface SearchDetailIntent : Intent {
     data class OnSearchQueryChanged(val query: String) : SearchDetailIntent
     data class RequestSearch(val query: String) : SearchDetailIntent
+    data class SelectSong(val song: SongUiData) : SearchDetailIntent
 }

--- a/feature/search/src/main/java/com/wepli/search/detail/screen/SearchDetailScreen.kt
+++ b/feature/search/src/main/java/com/wepli/search/detail/screen/SearchDetailScreen.kt
@@ -31,7 +31,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -304,9 +306,13 @@ fun SelectedSongSheet(
 ) {
     val scrollState = rememberScrollState()
     val brush = WepliTheme.color.linear3
+    var previousSize by remember { mutableIntStateOf(selectedSongs.size) }
 
     LaunchedEffect(selectedSongs.size) {
-        scrollState.scrollTo(scrollState.maxValue)
+        if (selectedSongs.size > previousSize) {
+            scrollState.scrollTo(scrollState.maxValue)
+        }
+        previousSize = selectedSongs.size
     }
 
     Column(

--- a/feature/search/src/main/java/com/wepli/search/detail/screen/SearchDetailScreen.kt
+++ b/feature/search/src/main/java/com/wepli/search/detail/screen/SearchDetailScreen.kt
@@ -177,7 +177,7 @@ fun SearchWithSelectedSheet(
         )
 
         if (state.selectedSongs.isNotEmpty()) {
-            SelectedSheet(
+            SelectedSongSheet(
                 selectedSongs = state.selectedSongs.toList(),
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
@@ -224,7 +224,7 @@ fun SearchResults(
         items(count = searchResult.size, key = { searchResult[it].id }) { idx ->
             val song = searchResult[idx]
 
-            SongItem(
+            SearchResultSongItem(
                 songUiData = song,
                 onClick = { sendAction(SearchDetailIntent.SelectSong(song)) },
                 modifier = Modifier
@@ -236,7 +236,7 @@ fun SearchResults(
 }
 
 @Composable
-fun SongItem(
+fun SearchResultSongItem(
     modifier: Modifier = Modifier,
     songUiData: SongUiData,
     onClick: () -> Unit,
@@ -281,7 +281,7 @@ fun SongItem(
 }
 
 @Composable
-fun SelectedSheet(
+fun SelectedSongSheet(
     selectedSongs: List<SongUiData>,
     modifier: Modifier = Modifier,
 ) {
@@ -383,4 +383,10 @@ fun SkeletonImage() {
 @Composable
 fun SearchScreenPreview() {
     SearchScreen(SearchScreenMode.NORMAL, SearchDetailUiState(searchMusicResult = songMockData), {}, {})
+}
+
+@Preview
+@Composable
+fun SelectedSongSheetPreview() {
+    SelectedSongSheet(songMockData, Modifier.fillMaxWidth())
 }

--- a/feature/search/src/main/java/com/wepli/search/detail/screen/SearchDetailScreen.kt
+++ b/feature/search/src/main/java/com/wepli/search/detail/screen/SearchDetailScreen.kt
@@ -125,6 +125,7 @@ fun SearchScreen(
                 SearchContent(
                     state = state,
                     paddingValues = paddingValues,
+                    onClickSongItem = { /* TODO */},
                     sendAction = sendAction,
                 )
             }
@@ -133,6 +134,7 @@ fun SearchScreen(
                 SearchWithSelectedSheet(
                     state = state,
                     paddingValues = paddingValues,
+                    onClickSongItem = { sendAction(SearchDetailIntent.OnSongSelected(it)) },
                     sendAction = sendAction,
                 )
             }
@@ -144,6 +146,7 @@ fun SearchScreen(
 fun SearchContent(
     state: SearchDetailUiState,
     paddingValues: PaddingValues,
+    onClickSongItem: (SongUiData) -> Unit,
     sendAction: (SearchDetailIntent) -> Unit,
 ) {
     Column(
@@ -159,8 +162,9 @@ fun SearchContent(
         )
 
         SearchResults(
+            key = state.searchInput,
             searchResult = state.searchMusicResult,
-            sendAction = sendAction,
+            onClickSongItem = { onClickSongItem(it) }
         )
     }
 }
@@ -169,12 +173,14 @@ fun SearchContent(
 fun SearchWithSelectedSheet(
     state: SearchDetailUiState,
     paddingValues: PaddingValues,
+    onClickSongItem: (SongUiData) -> Unit,
     sendAction: (SearchDetailIntent) -> Unit,
 ) {
     Box(modifier = Modifier.fillMaxSize()) {
         SearchContent(
             paddingValues = paddingValues,
             state = state,
+            onClickSongItem = onClickSongItem,
             sendAction = sendAction,
         )
 
@@ -210,11 +216,12 @@ fun SearchBar(
 
 @Composable
 fun SearchResults(
+    key: String,
     searchResult: List<SongUiData>,
-    sendAction: (SearchDetailIntent) -> Unit,
+    onClickSongItem: (SongUiData) -> Unit,
 ) {
     val lazyListState = rememberLazyListState()
-    LaunchedEffect(searchResult) {
+    LaunchedEffect(key) {
         lazyListState.scrollToItem(0)
     }
 
@@ -229,7 +236,7 @@ fun SearchResults(
 
             SearchResultSongItem(
                 songUiData = song,
-                onClick = { sendAction(SearchDetailIntent.OnSongSelected(song)) },
+                onClick = { onClickSongItem(song) },
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(52.dp),
@@ -246,6 +253,13 @@ fun SearchResultSongItem(
 ) {
     val imageSize = SongItemImageSize.toPx()
     val imageUrl = remember(songUiData.id) { songUiData.getImageUrl(imageSize) }
+    val titleStyle = WepliTheme.typo.body4.run {
+        if (songUiData.isSelected) {
+            copy(brush = WepliTheme.color.linear3)
+        } else {
+            copy(color = WepliTheme.color.white)
+        }
+    }
 
     Row(modifier = modifier.clickable { onClick() }) {
         AsyncImageWithPreview(
@@ -266,8 +280,7 @@ fun SearchResultSongItem(
         ) {
             Text(
                 text = songUiData.title,
-                style = WepliTheme.typo.body4,
-                color = WepliTheme.color.white,
+                style = titleStyle,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
             )

--- a/feature/search/src/main/java/com/wepli/search/detail/screen/SearchDetailScreen.kt
+++ b/feature/search/src/main/java/com/wepli/search/detail/screen/SearchDetailScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
@@ -104,13 +103,6 @@ fun SearchScreen(
     sendAction: (SearchDetailIntent) -> Unit,
     navOnBack: () -> Unit,
 ) {
-    val onQueryUpdate: (String) -> Unit = {
-        sendAction(SearchDetailIntent.OnSearchQueryChanged(it))
-    }
-    val onEnter: () -> Unit = {
-        sendAction(SearchDetailIntent.RequestSearch(state.searchInput))
-    }
-
     Scaffold(
         containerColor = WepliTheme.color.black,
         topBar = {
@@ -125,21 +117,17 @@ fun SearchScreen(
         when (screenMode) {
             SearchScreenMode.NORMAL -> {
                 SearchContent(
-                    paddingValues = paddingValues,
                     state = state,
+                    paddingValues = paddingValues,
                     sendAction = sendAction,
-                    onQueryUpdate = onQueryUpdate,
-                    onEnter = onEnter,
                 )
             }
 
             SearchScreenMode.SELECTABLE -> {
                 SearchWithSelectedSheet(
-                    paddingValues = paddingValues,
                     state = state,
+                    paddingValues = paddingValues,
                     sendAction = sendAction,
-                    onQueryUpdate = onQueryUpdate,
-                    onEnter = onEnter,
                 )
             }
         }
@@ -148,11 +136,9 @@ fun SearchScreen(
 
 @Composable
 fun SearchContent(
-    paddingValues: PaddingValues,
     state: SearchDetailUiState,
+    paddingValues: PaddingValues,
     sendAction: (SearchDetailIntent) -> Unit,
-    onQueryUpdate: (String) -> Unit,
-    onEnter: () -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -162,8 +148,8 @@ fun SearchContent(
     ) {
         SearchBar(
             searchQuery = state.searchInput,
-            onQueryUpdate = onQueryUpdate,
-            onEnter = onEnter
+            onQueryUpdate = { sendAction(SearchDetailIntent.OnSearchQueryChanged(it)) },
+            onEnter = { sendAction(SearchDetailIntent.RequestSearch(state.searchInput)) }
         )
 
         SearchResults(
@@ -175,19 +161,15 @@ fun SearchContent(
 
 @Composable
 fun SearchWithSelectedSheet(
-    paddingValues: PaddingValues,
     state: SearchDetailUiState,
+    paddingValues: PaddingValues,
     sendAction: (SearchDetailIntent) -> Unit,
-    onQueryUpdate: (String) -> Unit,
-    onEnter: () -> Unit,
 ) {
     Box(modifier = Modifier.fillMaxSize()) {
         SearchContent(
             paddingValues = paddingValues,
             state = state,
             sendAction = sendAction,
-            onQueryUpdate = onQueryUpdate,
-            onEnter = onEnter,
         )
 
         if (state.selectedSongs.isNotEmpty()) {

--- a/feature/search/src/main/java/com/wepli/search/detail/screen/SearchDetailScreen.kt
+++ b/feature/search/src/main/java/com/wepli/search/detail/screen/SearchDetailScreen.kt
@@ -1,7 +1,6 @@
 package com.wepli.search.detail.screen
 
 import android.annotation.SuppressLint
-import android.app.appsearch.SearchResults
 import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border

--- a/feature/search/src/main/java/com/wepli/search/detail/screen/SearchDetailScreen.kt
+++ b/feature/search/src/main/java/com/wepli/search/detail/screen/SearchDetailScreen.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -89,10 +90,10 @@ fun SearchScreenRoute(
 
     SearchScreen(
         screenMode = screenMode,
+        state = state,
+        sendAction = { viewModel.processIntent(it) },
         onQueryUpdate = { viewModel.processIntent(SearchDetailIntent.OnSearchQueryChanged(it)) },
         onEnter = { viewModel.processIntent(SearchDetailIntent.RequestSearch(state.searchInput)) },
-        searchQuery = state.searchInput,
-        searchResult = state.searchMusicResult,
         lazyListState = scrollState,
         navOnBack = { navOnBack() }
     )
@@ -103,14 +104,14 @@ fun SearchScreenRoute(
 @Composable
 fun SearchScreen(
     screenMode: SearchScreenMode,
+    state: SearchDetailUiState,
+    sendAction: (SearchDetailIntent) -> Unit,
     onQueryUpdate: (String) -> Unit,
     onEnter: () -> Unit,
-    searchQuery: String,
-    searchResult: List<SongUiData>,
     lazyListState: LazyListState,
     navOnBack: () -> Unit,
 ) {
-    LaunchedEffect(searchResult) {
+    LaunchedEffect(state.searchMusicResult) {
         lazyListState.scrollToItem(0)
     }
 
@@ -125,22 +126,23 @@ fun SearchScreen(
             )
         }
     ) { paddingValues ->
-        when(screenMode) {
+        when (screenMode) {
             SearchScreenMode.NORMAL -> {
                 SearchContent(
                     paddingValues = paddingValues,
-                    searchQuery = searchQuery,
-                    searchResult = searchResult,
+                    state = state,
+                    sendAction = sendAction,
                     onQueryUpdate = onQueryUpdate,
                     onEnter = onEnter,
                     lazyListState = lazyListState,
                 )
             }
+
             SearchScreenMode.SELECTABLE -> {
                 SearchWithSelectedSheet(
                     paddingValues = paddingValues,
-                    searchQuery = searchQuery,
-                    searchResult = searchResult,
+                    state = state,
+                    sendAction = sendAction,
                     onQueryUpdate = onQueryUpdate,
                     onEnter = onEnter,
                     lazyListState = lazyListState,
@@ -153,26 +155,27 @@ fun SearchScreen(
 @Composable
 fun SearchContent(
     paddingValues: PaddingValues,
-    searchQuery: String,
-    searchResult: List<SongUiData>,
+    state: SearchDetailUiState,
+    sendAction: (SearchDetailIntent) -> Unit,
     onQueryUpdate: (String) -> Unit,
     onEnter: () -> Unit,
     lazyListState: LazyListState
 ) {
     Column(
         modifier = Modifier
-        .fillMaxSize()
-        .padding(paddingValues)
-        .padding(horizontal = 20.dp)
+            .fillMaxSize()
+            .padding(paddingValues)
+            .padding(horizontal = 20.dp)
     ) {
         SearchBar(
-            searchQuery = searchQuery,
+            searchQuery = state.searchInput,
             onQueryUpdate = onQueryUpdate,
             onEnter = onEnter
         )
 
         SearchResults(
-            searchResult = searchResult,
+            searchResult = state.searchMusicResult,
+            sendAction = sendAction,
             lazyListState = lazyListState
         )
     }
@@ -181,8 +184,8 @@ fun SearchContent(
 @Composable
 fun SearchWithSelectedSheet(
     paddingValues: PaddingValues,
-    searchQuery: String,
-    searchResult: List<SongUiData>,
+    state: SearchDetailUiState,
+    sendAction: (SearchDetailIntent) -> Unit,
     onQueryUpdate: (String) -> Unit,
     onEnter: () -> Unit,
     lazyListState: LazyListState,
@@ -190,18 +193,21 @@ fun SearchWithSelectedSheet(
     Box(modifier = Modifier.fillMaxSize()) {
         SearchContent(
             paddingValues = paddingValues,
-            searchQuery = searchQuery,
-            searchResult = searchResult,
+            state = state,
+            sendAction = sendAction,
             onQueryUpdate = onQueryUpdate,
             onEnter = onEnter,
             lazyListState = lazyListState,
         )
 
-        SelectedSheet(
-            modifier = Modifier
-                .align(Alignment.BottomCenter)
-                .navigationBarsPadding()
-        )
+        if (state.selectedSongs.isNotEmpty()) {
+            SelectedSheet(
+                selectedSongs = state.selectedSongs.toList(),
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .navigationBarsPadding()
+            )
+        }
     }
 }
 
@@ -227,6 +233,7 @@ fun SearchBar(
 fun SearchResults(
     searchResult: List<SongUiData>,
     lazyListState: LazyListState,
+    sendAction: (SearchDetailIntent) -> Unit,
 ) {
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
@@ -235,11 +242,14 @@ fun SearchResults(
         contentPadding = PaddingValues(vertical = 24.dp)
     ) {
         items(count = searchResult.size, key = { searchResult[it].id }) { idx ->
+            val song = searchResult[idx]
+
             SongItem(
+                songUiData = song,
+                onClick = { sendAction(SearchDetailIntent.SelectSong(song)) },
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(52.dp),
-                songUiData = searchResult[idx]
             )
         }
     }
@@ -249,11 +259,12 @@ fun SearchResults(
 fun SongItem(
     modifier: Modifier = Modifier,
     songUiData: SongUiData,
+    onClick: () -> Unit,
 ) {
     val imageSize = 52.dp.toPx()
     val imageUrl = remember(songUiData.id) { songUiData.getImageUrl(imageSize) }
 
-    Row(modifier = modifier) {
+    Row(modifier = modifier.clickable { onClick() }) {
         AsyncImageWithPreview(
             modifier = Modifier
                 .fillMaxHeight()
@@ -289,9 +300,17 @@ fun SongItem(
     }
 }
 
-@Preview
 @Composable
-fun SelectedSheet(modifier: Modifier = Modifier) {
+fun SelectedSheet(
+    selectedSongs: List<SongUiData>,
+    modifier: Modifier = Modifier,
+) {
+    val scrollState = rememberScrollState()
+
+    LaunchedEffect(selectedSongs.size) {
+        scrollState.scrollTo(scrollState.maxValue)
+    }
+
     Column(
         modifier = modifier
             .fillMaxWidth()
@@ -302,17 +321,18 @@ fun SelectedSheet(modifier: Modifier = Modifier) {
     ) {
         Row(
             modifier = Modifier
-                .horizontalScroll(rememberScrollState())
+                .horizontalScroll(scrollState)
                 .padding(vertical = 12.dp, horizontal = 16.dp),
             horizontalArrangement = Arrangement.spacedBy(12.dp)
         ) {
-            repeat(10) {
-                SelectedSongItem(songMockData[it].title, songMockData[it].getImageUrl(40.dp.toPx()))
+            selectedSongs.forEach {
+                // TODO : getImageUrl 호출 시 사이즈 동일해야 캐싱 적용되니 수정 필요
+                SelectedSongItem(it.title, it.getImageUrl(52.dp.toPx()))
             }
         }
 
         WepliBasicButton(
-            title = "추가하기",
+            title = "${selectedSongs.size}곡 추가하기",
             isEnabled = true,
             onClick = { /* TODO */ },
             modifier = Modifier.padding(horizontal = 20.dp)
@@ -379,5 +399,5 @@ fun SkeletonImage() {
 @Preview
 @Composable
 fun SearchScreenPreview() {
-    SearchScreen(SearchScreenMode.NORMAL, {}, {}, "", songMockData, rememberLazyListState(), {})
+    SearchScreen(SearchScreenMode.NORMAL, SearchDetailUiState(searchMusicResult = songMockData), {}, {}, {}, rememberLazyListState(), {})
 }

--- a/feature/search/src/main/java/com/wepli/search/detail/screen/SearchDetailScreen.kt
+++ b/feature/search/src/main/java/com/wepli/search/detail/screen/SearchDetailScreen.kt
@@ -255,7 +255,7 @@ fun SearchResultSongItem(
                 .clip(RoundedCornerShape(4.dp)),
             imageUrl = imageUrl,
             contentScale = ContentScale.Crop,
-            imageOverrideSize = 52.dp,
+            imageOverrideSize = SongItemImageSize,
             loadingContent = { SkeletonImage() },
         )
 
@@ -388,7 +388,7 @@ fun SkeletonImage() {
     Box(
         modifier = Modifier
             .background(color = WepliTheme.color.gray500)
-            .size(52.dp)
+            .size(SongItemImageSize)
             .clip(RoundedCornerShape(4.dp))
             .shimmerEffect(4.dp)
     )

--- a/feature/search/src/main/java/com/wepli/search/detail/screen/SearchDetailScreen.kt
+++ b/feature/search/src/main/java/com/wepli/search/detail/screen/SearchDetailScreen.kt
@@ -60,6 +60,8 @@ import textfield.WepliTextField
 import textfield.WepliTextFieldType
 import theme.WepliTheme
 
+private val SongItemImageSize = 52.dp
+
 @Composable
 fun SearchScreenRoute(
     screenMode: SearchScreenMode,
@@ -239,7 +241,7 @@ fun SongItem(
     songUiData: SongUiData,
     onClick: () -> Unit,
 ) {
-    val imageSize = 52.dp.toPx()
+    val imageSize = SongItemImageSize.toPx()
     val imageUrl = remember(songUiData.id) { songUiData.getImageUrl(imageSize) }
 
     Row(modifier = modifier.clickable { onClick() }) {
@@ -304,8 +306,8 @@ fun SelectedSheet(
             horizontalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             selectedSongs.forEach {
-                // TODO : getImageUrl 호출 시 사이즈 동일해야 캐싱 적용되니 수정 필요
-                SelectedSongItem(it.title, it.getImageUrl(52.dp.toPx()))
+                // 캐싱된 이미지를 사용하기 위해 SongItem과 같은 Size의 이미지 url 사용
+                SelectedSongItem(it.title, it.getImageUrl(SongItemImageSize.toPx()))
             }
         }
 

--- a/feature/search/src/main/java/com/wepli/search/detail/screen/SearchDetailScreen.kt
+++ b/feature/search/src/main/java/com/wepli/search/detail/screen/SearchDetailScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
@@ -53,6 +54,7 @@ import com.wepli.uimodel.music.SongUiData
 import common.WepliSpacer
 import extensions.compose.shimmerEffect
 import extensions.compose.toPx
+import extensions.compose.topBorderWithRoundedCorners
 import image.AsyncImageWithPreview
 import org.orbitmvi.orbit.compose.collectAsState
 import org.orbitmvi.orbit.compose.collectSideEffect
@@ -286,6 +288,7 @@ fun SelectedSongSheet(
     modifier: Modifier = Modifier,
 ) {
     val scrollState = rememberScrollState()
+    val brush = WepliTheme.color.linear3
 
     LaunchedEffect(selectedSongs.size) {
         scrollState.scrollTo(scrollState.maxValue)
@@ -294,6 +297,7 @@ fun SelectedSongSheet(
     Column(
         modifier = modifier
             .fillMaxWidth()
+            .topBorderWithRoundedCorners(brush = brush, height = 1.dp, cornerRadius = 20.dp, alpha = 0.2f)
             .clip(RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp))
             .background(color = WepliTheme.color.black)
             .padding(top = 12.dp, bottom = 20.dp),
@@ -328,7 +332,7 @@ fun SelectedSongItem(
     val itemPadding = PaddingValues(top = 6.dp, bottom = 6.dp, start = 6.dp, end = 12.dp)
     val itemBrush = WepliTheme.color.linear3
 
-    Box {
+    Box(modifier = Modifier.widthIn(max = 200.dp)) {
         Box(
             modifier = Modifier
                 .clip(RoundedCornerShape(100.dp))
@@ -349,8 +353,7 @@ fun SelectedSongItem(
             AsyncImageWithPreview(
                 modifier = Modifier
                     .size(20.dp)
-                    .clip(CircleShape)
-                    .border(brush = itemBrush, shape = CircleShape, width = 1.dp),
+                    .clip(CircleShape),
                 imageUrl = imageUrl,
                 contentScale = ContentScale.Crop,
                 imageOverrideSize = 40.dp,

--- a/feature/search/src/main/java/com/wepli/search/detail/screen/SearchDetailScreen.kt
+++ b/feature/search/src/main/java/com/wepli/search/detail/screen/SearchDetailScreen.kt
@@ -1,22 +1,29 @@
 package com.wepli.search.detail.screen
 
 import android.annotation.SuppressLint
+import android.app.appsearch.SearchResults
 import android.widget.Toast
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
@@ -25,7 +32,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
@@ -34,10 +43,12 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import appbar.WepliAppBar
+import button.WepliBasicButton
 import com.wepli.search.detail.state.SearchDetailEffect
 import com.wepli.search.detail.state.SearchDetailIntent
 import com.wepli.search.detail.state.SearchDetailUiState
 import com.wepli.search.detail.viewmodel.SearchDetailViewModel
+import com.wepli.search.navigation.SearchScreenMode
 import com.wepli.shared.feature.mock.songMockData
 import com.wepli.uimodel.music.SongUiData
 import common.WepliSpacer
@@ -52,6 +63,7 @@ import theme.WepliTheme
 
 @Composable
 fun SearchScreenRoute(
+    screenMode: SearchScreenMode,
     searchQuery: String,
     navOnBack: () -> Unit,
 ) {
@@ -77,6 +89,7 @@ fun SearchScreenRoute(
     }
 
     SearchScreen(
+        screenMode = screenMode,
         onQueryUpdate = { viewModel.processIntent(SearchDetailIntent.OnSearchQueryChanged(it)) },
         onEnter = { viewModel.processIntent(SearchDetailIntent.RequestSearch(state.searchInput)) },
         searchQuery = state.searchInput,
@@ -90,6 +103,7 @@ fun SearchScreenRoute(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SearchScreen(
+    screenMode: SearchScreenMode,
     onQueryUpdate: (String) -> Unit,
     onEnter: () -> Unit,
     searchQuery: String,
@@ -112,38 +126,122 @@ fun SearchScreen(
             )
         }
     ) { paddingValues ->
-        Column(
-            modifier = Modifier
-                .padding(paddingValues)
-                .padding(horizontal = 20.dp)
-        ) {
-            Box(modifier = Modifier.padding(vertical = 10.dp)) {
-                WepliTextField(
-                    value = searchQuery,
-                    singleLine = true,
-                    onValueChanged = { onQueryUpdate(it) },
-                    onEnter = { onEnter() },
-                    placeholder = "검색어를 입력하세요.",
-                    type = WepliTextFieldType.Search
+        when(screenMode) {
+            SearchScreenMode.NORMAL -> {
+                SearchContent(
+                    paddingValues = paddingValues,
+                    searchQuery = searchQuery,
+                    searchResult = searchResult,
+                    onQueryUpdate = onQueryUpdate,
+                    onEnter = onEnter,
+                    lazyListState = lazyListState,
                 )
             }
-
-            LazyColumn(
-                modifier = Modifier.fillMaxSize(),
-                state = lazyListState,
-                verticalArrangement = Arrangement.spacedBy(12.dp)
-            ) {
-                item { WepliSpacer(vertical = 12.dp) }
-
-                items(count = searchResult.size, key = { searchResult[it].id }) { idx ->
-                    SongItem(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .height(52.dp),
-                        songUiData = searchResult[idx]
-                    )
-                }
+            SearchScreenMode.SELECTABLE -> {
+                SearchWithSelectedSheet(
+                    paddingValues = paddingValues,
+                    searchQuery = searchQuery,
+                    searchResult = searchResult,
+                    onQueryUpdate = onQueryUpdate,
+                    onEnter = onEnter,
+                    lazyListState = lazyListState,
+                )
             }
+        }
+    }
+}
+
+@Composable
+fun SearchContent(
+    paddingValues: PaddingValues,
+    searchQuery: String,
+    searchResult: List<SongUiData>,
+    onQueryUpdate: (String) -> Unit,
+    onEnter: () -> Unit,
+    lazyListState: LazyListState
+) {
+    Column(
+        modifier = Modifier
+        .fillMaxSize()
+        .padding(paddingValues)
+        .padding(horizontal = 20.dp)
+    ) {
+        SearchBar(
+            searchQuery = searchQuery,
+            onQueryUpdate = onQueryUpdate,
+            onEnter = onEnter
+        )
+
+        SearchResults(
+            searchResult = searchResult,
+            lazyListState = lazyListState
+        )
+    }
+}
+
+@Composable
+fun SearchWithSelectedSheet(
+    paddingValues: PaddingValues,
+    searchQuery: String,
+    searchResult: List<SongUiData>,
+    onQueryUpdate: (String) -> Unit,
+    onEnter: () -> Unit,
+    lazyListState: LazyListState,
+) {
+    Box(modifier = Modifier.fillMaxSize()) {
+        SearchContent(
+            paddingValues = paddingValues,
+            searchQuery = searchQuery,
+            searchResult = searchResult,
+            onQueryUpdate = onQueryUpdate,
+            onEnter = onEnter,
+            lazyListState = lazyListState,
+        )
+
+        SelectedSheet(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .navigationBarsPadding()
+        )
+    }
+}
+
+@Composable
+fun SearchBar(
+    searchQuery: String,
+    onQueryUpdate: (String) -> Unit,
+    onEnter: () -> Unit,
+) {
+    Box(modifier = Modifier.padding(vertical = 10.dp)) {
+        WepliTextField(
+            value = searchQuery,
+            singleLine = true,
+            onValueChanged = { onQueryUpdate(it) },
+            onEnter = { onEnter() },
+            placeholder = "검색어를 입력하세요.",
+            type = WepliTextFieldType.Search
+        )
+    }
+}
+
+@Composable
+fun SearchResults(
+    searchResult: List<SongUiData>,
+    lazyListState: LazyListState,
+) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        state = lazyListState,
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+        contentPadding = PaddingValues(vertical = 24.dp)
+    ) {
+        items(count = searchResult.size, key = { searchResult[it].id }) { idx ->
+            SongItem(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(52.dp),
+                songUiData = searchResult[idx]
+            )
         }
     }
 }
@@ -192,6 +290,82 @@ fun SongItem(
     }
 }
 
+@Preview
+@Composable
+fun SelectedSheet(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp))
+            .background(color = WepliTheme.color.black)
+            .padding(top = 12.dp, bottom = 20.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .horizontalScroll(rememberScrollState())
+                .padding(vertical = 12.dp, horizontal = 16.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            repeat(10) {
+                SelectedSongItem(songMockData[it].title, songMockData[it].getImageUrl(40.dp.toPx()))
+            }
+        }
+
+        WepliBasicButton(
+            title = "추가하기",
+            isEnabled = true,
+            onClick = { /* TODO */ },
+            modifier = Modifier.padding(horizontal = 20.dp)
+        )
+    }
+}
+
+@Composable
+fun SelectedSongItem(
+    title: String,
+    imageUrl: String,
+) {
+    Box {
+        Box(
+            modifier = Modifier
+                .clip(RoundedCornerShape(100.dp))
+                .matchParentSize()
+                .alpha(0.5f)
+                .border(brush = WepliTheme.color.linear3, shape = CircleShape, width = 1.dp)
+                .padding(top = 6.dp, bottom = 6.dp, start = 6.dp, end = 12.dp),
+        )
+
+        Row(
+            modifier = Modifier
+                .clip(RoundedCornerShape(100.dp))
+                .background(brush = WepliTheme.color.linear3, alpha = 0.1f)
+                .padding(top = 6.dp, bottom = 6.dp, start = 6.dp, end = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            AsyncImageWithPreview(
+                modifier = Modifier
+                    .size(20.dp)
+                    .clip(CircleShape)
+                    .border(brush = WepliTheme.color.linear3, shape = CircleShape, width = 1.dp),
+                imageUrl = imageUrl,
+                contentScale = ContentScale.Crop,
+                imageOverrideSize = 40.dp,
+                loadingContent = { SkeletonImage() },
+            )
+
+            Text(
+                text = title,
+                style = WepliTheme.typo.body6,
+                color = WepliTheme.color.white,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}
+
 @Composable
 fun SkeletonImage() {
     Box(
@@ -206,5 +380,5 @@ fun SkeletonImage() {
 @Preview
 @Composable
 fun SearchScreenPreview() {
-    SearchScreen({}, {}, "", songMockData, rememberLazyListState(), {})
+    SearchScreen(SearchScreenMode.NORMAL, {}, {}, "", songMockData, rememberLazyListState(), {})
 }

--- a/feature/search/src/main/java/com/wepli/search/detail/screen/SearchDetailScreen.kt
+++ b/feature/search/src/main/java/com/wepli/search/detail/screen/SearchDetailScreen.kt
@@ -71,6 +71,7 @@ fun SearchScreenRoute(
     screenMode: SearchScreenMode,
     searchQuery: String,
     navOnBack: () -> Unit,
+    navigateBackWithSelectedSongs: (List<SongUiData>) -> Unit,
 ) {
     val viewModel = hiltViewModel<SearchDetailViewModel>()
     val state: SearchDetailUiState by viewModel.collectAsState()
@@ -91,6 +92,9 @@ fun SearchScreenRoute(
             is SearchDetailEffect.SearchError -> {
                 Toast.makeText(context, sideEffect.message, Toast.LENGTH_SHORT).show()
             }
+            is SearchDetailEffect.NavigateBackWithResult -> {
+                navigateBackWithSelectedSongs(sideEffect.selectedSongs)
+            }
         }
     }
 
@@ -98,7 +102,7 @@ fun SearchScreenRoute(
         screenMode = screenMode,
         state = state,
         sendAction = { viewModel.processIntent(it) },
-        navOnBack = { navOnBack() }
+        navOnBack = { navOnBack() },
     )
 }
 
@@ -343,7 +347,7 @@ fun SelectedSongSheet(
         WepliBasicButton(
             title = "${selectedSongs.size}곡 추가하기",
             isEnabled = true,
-            onClick = { /* TODO */ },
+            onClick = { sendAction(SearchDetailIntent.OnCompleteSongSelect) },
             modifier = Modifier.padding(horizontal = 20.dp)
         )
     }

--- a/feature/search/src/main/java/com/wepli/search/detail/screen/SearchDetailScreen.kt
+++ b/feature/search/src/main/java/com/wepli/search/detail/screen/SearchDetailScreen.kt
@@ -229,7 +229,7 @@ fun SearchResults(
 
             SearchResultSongItem(
                 songUiData = song,
-                onClick = { sendAction(SearchDetailIntent.SelectSong(song)) },
+                onClick = { sendAction(SearchDetailIntent.OnSongSelected(song)) },
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(52.dp),
@@ -316,7 +316,7 @@ fun SelectedSongSheet(
                 SelectedSongItem(
                     title = it.title,
                     imageUrl = it.getImageUrl(SongItemImageSize.toPx()),
-                    onClick = { sendAction(SearchDetailIntent.SelectSong(it)) }
+                    onClick = { sendAction(SearchDetailIntent.OnSongSelected(it)) }
                 )
             }
         }

--- a/feature/search/src/main/java/com/wepli/search/detail/screen/SearchDetailScreen.kt
+++ b/feature/search/src/main/java/com/wepli/search/detail/screen/SearchDetailScreen.kt
@@ -69,7 +69,6 @@ fun SearchScreenRoute(
 ) {
     val viewModel = hiltViewModel<SearchDetailViewModel>()
     val state: SearchDetailUiState by viewModel.collectAsState()
-    val scrollState = rememberLazyListState()
     val context = LocalContext.current
 
     // 초기 상태 설정 및 검색 요청
@@ -92,9 +91,6 @@ fun SearchScreenRoute(
         screenMode = screenMode,
         state = state,
         sendAction = { viewModel.processIntent(it) },
-        onQueryUpdate = { viewModel.processIntent(SearchDetailIntent.OnSearchQueryChanged(it)) },
-        onEnter = { viewModel.processIntent(SearchDetailIntent.RequestSearch(state.searchInput)) },
-        lazyListState = scrollState,
         navOnBack = { navOnBack() }
     )
 }
@@ -106,13 +102,13 @@ fun SearchScreen(
     screenMode: SearchScreenMode,
     state: SearchDetailUiState,
     sendAction: (SearchDetailIntent) -> Unit,
-    onQueryUpdate: (String) -> Unit,
-    onEnter: () -> Unit,
-    lazyListState: LazyListState,
     navOnBack: () -> Unit,
 ) {
-    LaunchedEffect(state.searchMusicResult) {
-        lazyListState.scrollToItem(0)
+    val onQueryUpdate: (String) -> Unit = {
+        sendAction(SearchDetailIntent.OnSearchQueryChanged(it))
+    }
+    val onEnter: () -> Unit = {
+        sendAction(SearchDetailIntent.RequestSearch(state.searchInput))
     }
 
     Scaffold(
@@ -134,7 +130,6 @@ fun SearchScreen(
                     sendAction = sendAction,
                     onQueryUpdate = onQueryUpdate,
                     onEnter = onEnter,
-                    lazyListState = lazyListState,
                 )
             }
 
@@ -145,7 +140,6 @@ fun SearchScreen(
                     sendAction = sendAction,
                     onQueryUpdate = onQueryUpdate,
                     onEnter = onEnter,
-                    lazyListState = lazyListState,
                 )
             }
         }
@@ -159,7 +153,6 @@ fun SearchContent(
     sendAction: (SearchDetailIntent) -> Unit,
     onQueryUpdate: (String) -> Unit,
     onEnter: () -> Unit,
-    lazyListState: LazyListState
 ) {
     Column(
         modifier = Modifier
@@ -176,7 +169,6 @@ fun SearchContent(
         SearchResults(
             searchResult = state.searchMusicResult,
             sendAction = sendAction,
-            lazyListState = lazyListState
         )
     }
 }
@@ -188,7 +180,6 @@ fun SearchWithSelectedSheet(
     sendAction: (SearchDetailIntent) -> Unit,
     onQueryUpdate: (String) -> Unit,
     onEnter: () -> Unit,
-    lazyListState: LazyListState,
 ) {
     Box(modifier = Modifier.fillMaxSize()) {
         SearchContent(
@@ -197,7 +188,6 @@ fun SearchWithSelectedSheet(
             sendAction = sendAction,
             onQueryUpdate = onQueryUpdate,
             onEnter = onEnter,
-            lazyListState = lazyListState,
         )
 
         if (state.selectedSongs.isNotEmpty()) {
@@ -232,9 +222,13 @@ fun SearchBar(
 @Composable
 fun SearchResults(
     searchResult: List<SongUiData>,
-    lazyListState: LazyListState,
     sendAction: (SearchDetailIntent) -> Unit,
 ) {
+    val lazyListState = rememberLazyListState()
+    LaunchedEffect(searchResult) {
+        lazyListState.scrollToItem(0)
+    }
+
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
         state = lazyListState,
@@ -399,5 +393,5 @@ fun SkeletonImage() {
 @Preview
 @Composable
 fun SearchScreenPreview() {
-    SearchScreen(SearchScreenMode.NORMAL, SearchDetailUiState(searchMusicResult = songMockData), {}, {}, {}, rememberLazyListState(), {})
+    SearchScreen(SearchScreenMode.NORMAL, SearchDetailUiState(searchMusicResult = songMockData), {}, {})
 }

--- a/feature/search/src/main/java/com/wepli/search/detail/screen/SearchDetailScreen.kt
+++ b/feature/search/src/main/java/com/wepli/search/detail/screen/SearchDetailScreen.kt
@@ -325,21 +325,24 @@ fun SelectedSongItem(
     title: String,
     imageUrl: String,
 ) {
+    val itemPadding = PaddingValues(top = 6.dp, bottom = 6.dp, start = 6.dp, end = 12.dp)
+    val itemBrush = WepliTheme.color.linear3
+
     Box {
         Box(
             modifier = Modifier
                 .clip(RoundedCornerShape(100.dp))
                 .matchParentSize()
                 .alpha(0.5f)
-                .border(brush = WepliTheme.color.linear3, shape = CircleShape, width = 1.dp)
-                .padding(top = 6.dp, bottom = 6.dp, start = 6.dp, end = 12.dp),
+                .border(brush = itemBrush, shape = CircleShape, width = 1.dp)
+                .padding(itemPadding),
         )
 
         Row(
             modifier = Modifier
                 .clip(RoundedCornerShape(100.dp))
-                .background(brush = WepliTheme.color.linear3, alpha = 0.1f)
-                .padding(top = 6.dp, bottom = 6.dp, start = 6.dp, end = 12.dp),
+                .background(brush = itemBrush, alpha = 0.1f)
+                .padding(itemPadding),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {
@@ -347,7 +350,7 @@ fun SelectedSongItem(
                 modifier = Modifier
                     .size(20.dp)
                     .clip(CircleShape)
-                    .border(brush = WepliTheme.color.linear3, shape = CircleShape, width = 1.dp),
+                    .border(brush = itemBrush, shape = CircleShape, width = 1.dp),
                 imageUrl = imageUrl,
                 contentScale = ContentScale.Crop,
                 imageOverrideSize = 40.dp,

--- a/feature/search/src/main/java/com/wepli/search/detail/screen/SearchDetailScreen.kt
+++ b/feature/search/src/main/java/com/wepli/search/detail/screen/SearchDetailScreen.kt
@@ -318,10 +318,10 @@ fun SelectedSongSheet(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .topBorderWithRoundedCorners(brush = brush, height = 1.dp, cornerRadius = 20.dp, alpha = 0.2f)
+            .topBorderWithRoundedCorners(brush = brush, height = 1.dp, cornerRadius = 20.dp, alpha = 0.1f)
             .clip(RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp))
             .background(color = WepliTheme.color.black)
-            .padding(top = 12.dp, bottom = 20.dp),
+            .padding(vertical = 20.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         Row(

--- a/feature/search/src/main/java/com/wepli/search/detail/screen/SearchDetailScreen.kt
+++ b/feature/search/src/main/java/com/wepli/search/detail/screen/SearchDetailScreen.kt
@@ -181,6 +181,7 @@ fun SearchWithSelectedSheet(
         if (state.selectedSongs.isNotEmpty()) {
             SelectedSongSheet(
                 selectedSongs = state.selectedSongs.toList(),
+                sendAction = sendAction,
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
                     .navigationBarsPadding()
@@ -285,6 +286,7 @@ fun SearchResultSongItem(
 @Composable
 fun SelectedSongSheet(
     selectedSongs: List<SongUiData>,
+    sendAction: (SearchDetailIntent) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val scrollState = rememberScrollState()
@@ -311,7 +313,11 @@ fun SelectedSongSheet(
         ) {
             selectedSongs.forEach {
                 // 캐싱된 이미지를 사용하기 위해 SongItem과 같은 Size의 이미지 url 사용
-                SelectedSongItem(it.title, it.getImageUrl(SongItemImageSize.toPx()))
+                SelectedSongItem(
+                    title = it.title,
+                    imageUrl = it.getImageUrl(SongItemImageSize.toPx()),
+                    onClick = { sendAction(SearchDetailIntent.SelectSong(it)) }
+                )
             }
         }
 
@@ -328,11 +334,17 @@ fun SelectedSongSheet(
 fun SelectedSongItem(
     title: String,
     imageUrl: String,
+    onClick: () -> Unit,
 ) {
     val itemPadding = PaddingValues(top = 6.dp, bottom = 6.dp, start = 6.dp, end = 12.dp)
     val itemBrush = WepliTheme.color.linear3
 
-    Box(modifier = Modifier.widthIn(max = 200.dp)) {
+    Box(
+        modifier = Modifier
+            .clickable { onClick() }
+            .widthIn(max = 200.dp)
+    ) {
+        // 테투리 오버레이
         Box(
             modifier = Modifier
                 .clip(RoundedCornerShape(100.dp))
@@ -391,5 +403,5 @@ fun SearchScreenPreview() {
 @Preview
 @Composable
 fun SelectedSongSheetPreview() {
-    SelectedSongSheet(songMockData, Modifier.fillMaxWidth())
+    SelectedSongSheet(songMockData, {}, Modifier.fillMaxWidth())
 }

--- a/feature/search/src/main/java/com/wepli/search/detail/screen/SearchDetailScreen.kt
+++ b/feature/search/src/main/java/com/wepli/search/detail/screen/SearchDetailScreen.kt
@@ -73,8 +73,10 @@ fun SearchScreenRoute(
     // 초기 상태 설정 및 검색 요청
     LaunchedEffect(searchQuery) {
         if (searchQuery.isNotEmpty()) {
-            viewModel.processIntent(SearchDetailIntent.OnSearchQueryChanged(searchQuery))
-            viewModel.processIntent(SearchDetailIntent.RequestSearch(searchQuery))
+            viewModel.processIntent(
+                SearchDetailIntent.OnSearchQueryChanged(searchQuery),
+                SearchDetailIntent.RequestSearch(searchQuery)
+            )
         }
     }
 

--- a/feature/search/src/main/java/com/wepli/search/detail/screen/SearchDetailScreen.kt
+++ b/feature/search/src/main/java/com/wepli/search/detail/screen/SearchDetailScreen.kt
@@ -43,9 +43,9 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import appbar.WepliAppBar
 import button.WepliBasicButton
-import com.wepli.search.detail.state.SearchDetailEffect
-import com.wepli.search.detail.state.SearchDetailIntent
-import com.wepli.search.detail.state.SearchDetailUiState
+import com.wepli.search.detail.mvi.SearchDetailEffect
+import com.wepli.search.detail.mvi.SearchDetailIntent
+import com.wepli.search.detail.mvi.SearchDetailUiState
 import com.wepli.search.detail.viewmodel.SearchDetailViewModel
 import com.wepli.search.navigation.SearchScreenMode
 import com.wepli.shared.feature.mock.songMockData

--- a/feature/search/src/main/java/com/wepli/search/detail/viewmodel/SearchDetailViewModel.kt
+++ b/feature/search/src/main/java/com/wepli/search/detail/viewmodel/SearchDetailViewModel.kt
@@ -2,9 +2,9 @@ package com.wepli.search.detail.viewmodel
 
 import base.BaseMviViewModel
 import com.wepli.core.kotlin.suspendCollectResult
-import com.wepli.search.detail.state.SearchDetailEffect
-import com.wepli.search.detail.state.SearchDetailIntent
-import com.wepli.search.detail.state.SearchDetailUiState
+import com.wepli.search.detail.mvi.SearchDetailEffect
+import com.wepli.search.detail.mvi.SearchDetailIntent
+import com.wepli.search.detail.mvi.SearchDetailUiState
 import com.wepli.uimodel.music.SongUiData
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers

--- a/feature/search/src/main/java/com/wepli/search/detail/viewmodel/SearchDetailViewModel.kt
+++ b/feature/search/src/main/java/com/wepli/search/detail/viewmodel/SearchDetailViewModel.kt
@@ -22,7 +22,7 @@ class SearchDetailViewModel @Inject constructor(
         when (intent) {
             is SearchDetailIntent.OnSearchQueryChanged -> handleSearchQueryChanged(intent.query)
             is SearchDetailIntent.RequestSearch -> searchMusic(intent.query)
-            is SearchDetailIntent.SelectSong -> handleSongSelected(intent.song)
+            is SearchDetailIntent.OnSongSelected -> handleSongSelected(intent.song)
         }
     }
 

--- a/feature/search/src/main/java/com/wepli/search/detail/viewmodel/SearchDetailViewModel.kt
+++ b/feature/search/src/main/java/com/wepli/search/detail/viewmodel/SearchDetailViewModel.kt
@@ -22,6 +22,7 @@ class SearchDetailViewModel @Inject constructor(
         when (intent) {
             is SearchDetailIntent.OnSearchQueryChanged -> handleSearchQueryChanged(intent.query)
             is SearchDetailIntent.RequestSearch -> searchMusic(intent.query)
+            is SearchDetailIntent.SelectSong -> handleSongSelected(intent.song)
         }
     }
 
@@ -47,6 +48,16 @@ class SearchDetailViewModel @Inject constructor(
                 },
                 onFailure = {
                     postSideEffect(SearchDetailEffect.SearchError(it.message ?: "알 수 없는 오류가 발생하였습니다."))
+                }
+            )
+        }
+    }
+
+    private fun handleSongSelected(song: SongUiData) = intent {
+        reduce {
+            state.copy(
+                selectedSongs = LinkedHashSet(state.selectedSongs).apply {
+                    if (!add(song)) remove(song)
                 }
             )
         }

--- a/feature/search/src/main/java/com/wepli/search/detail/viewmodel/SearchDetailViewModel.kt
+++ b/feature/search/src/main/java/com/wepli/search/detail/viewmodel/SearchDetailViewModel.kt
@@ -43,7 +43,11 @@ class SearchDetailViewModel @Inject constructor(
             }.suspendCollectResult(
                 onSuccess = { musics ->
                     reduce {
-                        state.copy(searchMusicResult = musics.map(SongUiData::fromDomain))
+                        state.copy(
+                            searchMusicResult = musics
+                                .map(SongUiData::fromDomain)
+                                .updateSelectionState(state.selectedSongs)
+                        )
                     }
                 },
                 onFailure = {
@@ -55,11 +59,24 @@ class SearchDetailViewModel @Inject constructor(
 
     private fun handleSongSelected(song: SongUiData) = intent {
         reduce {
+            val updatedSelectedSongs = LinkedHashSet(state.selectedSongs).apply {
+                if (!add(song)) remove(song)
+            }
+
+            val updatedSearchMusicResult = state.searchMusicResult.map {
+                if (it.id == song.id) it.copy(isSelected = !it.isSelected) else it
+            }
+
             state.copy(
-                selectedSongs = LinkedHashSet(state.selectedSongs).apply {
-                    if (!add(song)) remove(song)
-                }
+                selectedSongs = updatedSelectedSongs,
+                searchMusicResult = updatedSearchMusicResult
             )
+        }
+    }
+
+    private fun List<SongUiData>.updateSelectionState(selectedSongs: Set<SongUiData>): List<SongUiData> {
+        return this.map { song ->
+            song.copy(isSelected = selectedSongs.contains(song))
         }
     }
 }

--- a/feature/search/src/main/java/com/wepli/search/detail/viewmodel/SearchDetailViewModel.kt
+++ b/feature/search/src/main/java/com/wepli/search/detail/viewmodel/SearchDetailViewModel.kt
@@ -23,6 +23,7 @@ class SearchDetailViewModel @Inject constructor(
             is SearchDetailIntent.OnSearchQueryChanged -> handleSearchQueryChanged(intent.query)
             is SearchDetailIntent.RequestSearch -> searchMusic(intent.query)
             is SearchDetailIntent.OnSongSelected -> handleSongSelected(intent.song)
+            is SearchDetailIntent.OnCompleteSongSelect -> handleCompleteSongSelect()
         }
     }
 
@@ -78,5 +79,9 @@ class SearchDetailViewModel @Inject constructor(
         return this.map { song ->
             song.copy(isSelected = selectedSongs.contains(song))
         }
+    }
+
+    private fun handleCompleteSongSelect() = intent {
+        postSideEffect(SearchDetailEffect.NavigateBackWithResult(state.selectedSongs.toList()))
     }
 }

--- a/feature/search/src/main/java/com/wepli/search/navigation/SearchScreenMode.kt
+++ b/feature/search/src/main/java/com/wepli/search/navigation/SearchScreenMode.kt
@@ -1,0 +1,15 @@
+package com.wepli.search.navigation
+
+enum class SearchScreenMode {
+    NORMAL,
+    SELECTABLE;
+
+    companion object {
+        fun fromString(value: String): SearchScreenMode {
+            return when (value.uppercase()) {
+                "SELECTABLE" -> SELECTABLE
+                else -> NORMAL
+            }
+        }
+    }
+}

--- a/feature/search/src/main/java/com/wepli/search/navigation/searchNavigation.kt
+++ b/feature/search/src/main/java/com/wepli/search/navigation/searchNavigation.kt
@@ -9,8 +9,8 @@ import com.wepli.search.detail.screen.SearchScreenRoute
 import extensions.enterAnimation
 
 // Controller - 화면 이동을 담당
-fun NavController.navigateToSearchDetail(searchQuery: String) {
-    navigate("${SearchRoute.DETAIL.route}/$searchQuery")
+fun NavController.navigateToSearchDetail(screenMode: SearchScreenMode, searchQuery: String) {
+    navigate("${SearchRoute.DETAIL.route}/$screenMode/$searchQuery")
 }
 
 fun NavGraphBuilder.searchMainGraph(
@@ -25,11 +25,14 @@ fun NavGraphBuilder.searchDetailGraph(
     navOnBack: () -> Unit
 ) {
     composable(
-        route = "${SearchRoute.DETAIL.route}/{searchQuery}",
+        route = "${SearchRoute.DETAIL.route}/{screenMode}/{searchQuery}",
         enterTransition = { enterAnimation() }
     ) {
+        val screenMode = SearchScreenMode.fromString(
+            it.arguments?.getString("screenMode").orEmpty()
+        )
         val searchQuery = it.arguments?.getString("searchQuery").orEmpty()
 
-        SearchScreenRoute(searchQuery, navOnBack)
+        SearchScreenRoute(screenMode, searchQuery, navOnBack)
     }
 }

--- a/feature/search/src/main/java/com/wepli/search/navigation/searchNavigation.kt
+++ b/feature/search/src/main/java/com/wepli/search/navigation/searchNavigation.kt
@@ -3,14 +3,21 @@ package com.wepli.search.navigation
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
+import com.wepli.navigator.extras.Extras
 import com.wepli.navigator.feature.search.SearchRoute
 import com.wepli.search.main.screen.SearchMainScreenRoute
 import com.wepli.search.detail.screen.SearchScreenRoute
+import com.wepli.uimodel.music.SongUiData
 import extensions.enterAnimation
 
 // Controller - 화면 이동을 담당
 fun NavController.navigateToSearchDetail(screenMode: SearchScreenMode, searchQuery: String) {
     navigate("${SearchRoute.DETAIL.route}/$screenMode/$searchQuery")
+}
+
+fun NavController.navigateBackWithSelectedSongs(selectedSongs: List<SongUiData>) {
+    previousBackStackEntry?.savedStateHandle?.set(Extras.SELECTED_SONGS, selectedSongs)
+    navigateUp()
 }
 
 fun NavGraphBuilder.searchMainGraph(
@@ -22,7 +29,8 @@ fun NavGraphBuilder.searchMainGraph(
 }
 
 fun NavGraphBuilder.searchDetailGraph(
-    navOnBack: () -> Unit
+    navOnBack: () -> Unit,
+    navigateBackWithSelectedSongs: (List<SongUiData>) -> Unit
 ) {
     composable(
         route = "${SearchRoute.DETAIL.route}/{screenMode}/{searchQuery}",
@@ -33,6 +41,6 @@ fun NavGraphBuilder.searchDetailGraph(
         )
         val searchQuery = it.arguments?.getString("searchQuery").orEmpty()
 
-        SearchScreenRoute(screenMode, searchQuery, navOnBack)
+        SearchScreenRoute(screenMode, searchQuery, navOnBack, navigateBackWithSelectedSongs)
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,23 +1,17 @@
-# Project-wide Gradle settings.
-# IDE (e.g. Android Studio) users:
-# Gradle settings configured through the IDE *will override*
-# any settings specified in this file.
-# For more details on how to configure your build environment visit
+## For more details on how to configure your build environment visit
 # http://www.gradle.org/docs/current/userguide/build_environment.html
+#
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+# Default value: -Xmx1024m -XX:MaxPermSize=256m
+# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+#
 # When configured, Gradle will run in incubating parallel mode.
-# This option should only be used with decoupled projects. More details, visit
-# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
+# This option should only be used with decoupled projects. For more details, visit
+# https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects
 # org.gradle.parallel=true
-# AndroidX package structure to make it clearer which packages are bundled with the
-# Android operating system, and which are packaged with your app's APK
-# https://developer.android.com/topic/libraries/support-library/androidx-rn
-android.useAndroidX=true
-# Kotlin code style for this project: "official" or "obsolete":
-kotlin.code.style=official
-# Enables namespacing of each library's R class so that its R class includes only the
-# resources declared in the library itself and none from the library's dependencies,
-# thereby reducing the size of the R class for that library
+#Mon Jan 27 22:52:26 KST 2025
 android.nonTransitiveRClass=true
+android.useAndroidX=true
+kotlin.code.style=official
+org.gradle.jvmargs=-Xmx1536M -Dkotlin.daemon.jvm.options\="-Xmx2048M" -Dfile.encoding\=UTF-8

--- a/shared/feature/src/main/java/com/wepli/shared/feature/uimodel/music/SongUiData.kt
+++ b/shared/feature/src/main/java/com/wepli/shared/feature/uimodel/music/SongUiData.kt
@@ -22,7 +22,16 @@ data class SongUiData(
     val href: String = "",
     val genres: List<String> = emptyList(),
     val durationMillis: Long = 0L,
+    val isSelected: Boolean = false,
 ) : UiModel {
+
+    override fun equals(other: Any?): Boolean {
+        return other is SongUiData && id == other.id
+    }
+
+    override fun hashCode(): Int {
+        return id.hashCode()
+    }
 
     fun getImageUrl(size: Int): String {
         return getImageUrl(size, size)


### PR DESCRIPTION
### 변경사항
- 검색 화면에서 노래 선택할 수 있도록 수정
   - Navigation 파라미터로 Type을 전달하여 분기
- Navigation 이전 화면으로 데이터 전달 로직 추가
- border Modifier 확장 함수 추가
   -  특정 방향에만 border 추가하는 확장 함수 추가
   - 상단 테두리에 맞게 border 추가하는 확장 함수 추가
- Orbit updateState 확장 함수 추가

### 이슈 메모
**Navigation backStackEntry 문제**
   - 아래와 같이 SearchDetailScreen에서 선택한 곡을 previousBackStackEntry에 저장하고, 
      CommunityWriteGraph에서 참조하는 방식으로 데이터 전달
   - CommunityWriteGraph에서 데이터를 가져올 때 get으로만 가져오면 데이터는 savedStateHandle에 그대로 남아있게 됨
   - 데이터가 남아 있는 상태에서 SearchDetailScreen에 들어갔다 나오기만해도 데이터가 다시 전달됨
```kotlin
fun NavController.navigateBackWithSelectedSongs(selectedSongs: List<SongUiData>) {
    previousBackStackEntry?.savedStateHandle?.set(Extras.SELECTED_SONGS, selectedSongs)
    navigateUp()
}
```
```kotlin
fun NavGraphBuilder.communityWriteGraph(
    navOnBack: () -> Unit,
    navOnSearchDetail: () -> Unit
) {
    composable(CommunityRoute.Write.route) {
        // remove 대신 get을 사용하는 경우 savedStateHandle에 값이 남아있어 문제가 됨
        // 노래 검색 화면에 들어갔다 나오기만해도 savedStateHandle에 남아있던 값이 Screen으로 전달됨
        val selectedSongs: List<SongUiData>? = it.savedStateHandle.remove<List<SongUiData>>(Extras.SELECTED_SONGS)

        CommunityWriteScreenRoute(selectedSongs, navOnBack, navOnSearchDetail)
    }
}
```

### 스크린샷

| 노래 선택 화면 | 노래 추가 완료 화면 |
|--------------|------------------|
| <img width="395" alt="image" src="https://github.com/user-attachments/assets/60a3b51a-7069-4473-91f0-9c7db1ee4424" /> | <img width="439" alt="image" src="https://github.com/user-attachments/assets/0d114da9-581c-41d0-8b35-4ec969598485" /> |
