### PR TITLE
[Feature/fetch_posts] 게시글 조회 로직 추가

### DIFF
--- a/app/src/main/java/com/wepli/app/navigation/NavHost.kt
+++ b/app/src/main/java/com/wepli/app/navigation/NavHost.kt
@@ -19,6 +19,7 @@ import com.wepli.mypage.menus.appinfo.navigation.navigateToAppInfo
 import com.wepli.mypage.menus.mypage.navigation.mypageMainGraph
 import com.wepli.app.navigation.extensions.navigateToBack
 import com.wepli.community.navigation.communityWriteGraph
+import com.wepli.community.navigation.navigateToBackAndPostRefresh
 import com.wepli.community.navigation.navigateToCommunityWrite
 import com.wepli.playlist.navigation.navigateToPlaylistDetail
 import com.wepli.playlist.navigation.playlistDetailGraph
@@ -95,6 +96,7 @@ fun NavGraphBuilder.communityGraph(navController: NavHostController) {
     )
     communityWriteGraph(
         navOnBack = { navController.navigateToBack() },
+        navOnBackAndPostRefresh = { navController.navigateToBackAndPostRefresh() },
         navOnSearchDetail = {
             navController.navigateToSearchDetail(
                 screenMode = SearchScreenMode.SELECTABLE,

--- a/core/common/src/main/kotlin/base/BaseMviViewModel.kt
+++ b/core/common/src/main/kotlin/base/BaseMviViewModel.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.ContainerHost

--- a/core/common/src/main/kotlin/base/BaseMviViewModel.kt
+++ b/core/common/src/main/kotlin/base/BaseMviViewModel.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.annotation.OrbitDsl
 import org.orbitmvi.orbit.viewmodel.container
 
 abstract class BaseMviViewModel<S : UiState, E : SideEffect, I : Intent>(
@@ -26,11 +27,19 @@ abstract class BaseMviViewModel<S : UiState, E : SideEffect, I : Intent>(
         throw throwable
     }
 
+    @OrbitDsl
     protected inline fun <STATE : Any> ContainerHost<STATE, *>.updateState(
         crossinline reducer: STATE.() -> STATE
     ) {
         intent {
             reduce { state.reducer() }
+        }
+    }
+
+    @OrbitDsl
+    protected inline fun postSideEffect(crossinline sideEffect: () -> E) {
+        intent {
+            postSideEffect(sideEffect())
         }
     }
 

--- a/core/navigator/src/main/java/com/wepli/navigator/extras/Extras.kt
+++ b/core/navigator/src/main/java/com/wepli/navigator/extras/Extras.kt
@@ -2,4 +2,5 @@ package com.wepli.navigator.extras
 
 object Extras {
     const val SELECTED_SONGS = "SELECTED_SONGS"
+    const val COMMUNITY_NEED_REFRESH_POST = "COMMUNITY_NEED_REFRESH_POST"
 }

--- a/data/src/main/kotlin/com/wepli/data/SupabaseTable.kt
+++ b/data/src/main/kotlin/com/wepli/data/SupabaseTable.kt
@@ -5,5 +5,6 @@ object SupabaseTable {
     const val CHART_TABLE = "music_chart"
     const val SONG_TABLE = "song"
     const val POST_TABLE = "posts"
+    const val POST_VIEW = "post_tree_view"
     const val POST_BSIDE_TRACK_TABLE = "post_bside_track"
 }

--- a/data/src/main/kotlin/com/wepli/data/post/datasource/PostDataSource.kt
+++ b/data/src/main/kotlin/com/wepli/data/post/datasource/PostDataSource.kt
@@ -1,9 +1,11 @@
 package com.wepli.data.post.datasource
 
 import com.wepli.core.kotlin.FlowResult
+import com.wepli.data.post.response.PostResponse
 import model.community.Post
 
 interface PostDataSource {
 
+    fun getPosts(): FlowResult<List<PostResponse>>
     fun addPost(post: Post): FlowResult<Unit>
 }

--- a/data/src/main/kotlin/com/wepli/data/post/datasource/PostSupabaseDataSourceImpl.kt
+++ b/data/src/main/kotlin/com/wepli/data/post/datasource/PostSupabaseDataSourceImpl.kt
@@ -31,6 +31,7 @@ class PostSupabaseDataSourceImpl @Inject constructor(
 
     override fun getPosts(): FlowResult<List<PostResponse>> = flow {
         val result = runCatching {
+            throw Exception("Not implemented")
             supabase.postgrest[SupabaseTable.POST_VIEW].select().decodeList<PostResponse>()
         }
 

--- a/data/src/main/kotlin/com/wepli/data/post/datasource/PostSupabaseDataSourceImpl.kt
+++ b/data/src/main/kotlin/com/wepli/data/post/datasource/PostSupabaseDataSourceImpl.kt
@@ -8,6 +8,7 @@ import com.wepli.data.post.request.PostBsideTrackRequestBody
 import com.wepli.data.post.request.PostRequestBody
 import com.wepli.data.post.request.toPostRequest
 import com.wepli.data.post.request.mapToSongRequest
+import com.wepli.data.post.response.PostResponse
 import com.wepli.data.song.datasource.SongDataSource
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.postgrest.postgrest
@@ -27,6 +28,14 @@ class PostSupabaseDataSourceImpl @Inject constructor(
     private val supabase: SupabaseClient,
     @SupabaseDataSource private val songDataSource: SongDataSource,
 ) : PostDataSource {
+
+    override fun getPosts(): FlowResult<List<PostResponse>> = flow {
+        val result = runCatching {
+            supabase.postgrest[SupabaseTable.POST_VIEW].select().decodeList<PostResponse>()
+        }
+
+        emit(result)
+    }
 
     @OptIn(ExperimentalCoroutinesApi::class)
     override fun addPost(post: Post): FlowResult<Unit> {

--- a/data/src/main/kotlin/com/wepli/data/post/repository/PostRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/wepli/data/post/repository/PostRepositoryImpl.kt
@@ -2,7 +2,9 @@ package com.wepli.data.post.repository
 
 import com.wepli.core.kotlin.FlowResult
 import com.wepli.data.di.qualifier.SupabaseDataSource
+import com.wepli.data.network.toEntityResult
 import com.wepli.data.post.datasource.PostDataSource
+import com.wepli.data.post.response.toPosts
 import model.community.Post
 import repository.post.PostRepository
 import javax.inject.Inject
@@ -10,6 +12,10 @@ import javax.inject.Inject
 class PostRepositoryImpl @Inject constructor(
     @SupabaseDataSource private val postDataSource: PostDataSource,
 ) : PostRepository {
+
+    override fun getPosts(): FlowResult<List<Post>> {
+        return postDataSource.getPosts().toEntityResult { it.toPosts() }
+    }
 
     override fun addPost(post: Post): FlowResult<Unit> {
         return postDataSource.addPost(post)

--- a/data/src/main/kotlin/com/wepli/data/post/response/PostResponse.kt
+++ b/data/src/main/kotlin/com/wepli/data/post/response/PostResponse.kt
@@ -1,0 +1,37 @@
+package com.wepli.data.post.response
+
+import com.wepli.data.song.response.SongResponse
+import com.wepli.data.song.response.toSong
+import com.wepli.data.user.response.UserResponse
+import com.wepli.data.user.response.toUser
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import model.community.Post
+
+@Serializable
+data class PostResponse(
+    @SerialName("post_id")
+    val id: Int,
+    @SerialName("post_title")
+    val title: String,
+    @SerialName("post_contents")
+    val contents: String,
+    @SerialName("user")
+    val author: UserResponse,
+    @SerialName("song_list")
+    val songList: List<SongResponse>,
+)
+
+fun List<PostResponse>.toPosts(): List<Post> {
+    return map { it.toPost() }
+}
+
+fun PostResponse.toPost(): Post {
+    return Post(
+        id = id,
+        title = title,
+        content = contents,
+        author = author.toUser(),
+        songList = songList.map { it.toSong() },
+    )
+}

--- a/data/src/main/kotlin/com/wepli/data/song/response/SongResponse.kt
+++ b/data/src/main/kotlin/com/wepli/data/song/response/SongResponse.kt
@@ -1,0 +1,38 @@
+package com.wepli.data.song.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import model.music.Song
+
+@Serializable
+data class SongResponse(
+    @SerialName("id")
+    val id: Int,
+    @SerialName("song_id")
+    val songId: String, // Apple Music Song Id
+    @SerialName("title")
+    val title: String,
+    @SerialName("artist_name")
+    val artist: String,
+    @SerialName("album")
+    val album: String,
+    @SerialName("cover_img")
+    val coverImg: String,
+    @SerialName("href")
+    val href: String,
+    @SerialName("duration_millis")
+    val duration: Int,
+)
+
+fun SongResponse.toSong(): Song {
+    return Song(
+        id = songId,
+        title = title,
+        artistName = artist,
+        albumName = album,
+        coverImg = coverImg,
+        href = href,
+        durationMillis = duration.toLong(),
+        genres = emptyList(),
+    )
+}

--- a/designsystem/src/main/kotlin/custom/SongItem.kt
+++ b/designsystem/src/main/kotlin/custom/SongItem.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -22,6 +23,7 @@ import androidx.compose.ui.unit.dp
 import com.wepli.designsystem.R
 import com.wepli.shared.feature.mock.songUiMockData
 import com.wepli.uimodel.music.SongUiData
+import common.ShimmerSkeleton
 import extensions.compose.toPx
 import image.AsyncImageWithPreview
 import theme.WepliTheme
@@ -30,24 +32,32 @@ import theme.WepliTheme
 fun SongItem(
     song: SongUiData,
     onClick: () -> Unit = {},
-    loadingContent: @Composable () -> Unit = {},
+    loadingContent: @Composable (() -> Unit)? = null,
 ) {
-    val imagePixel = 92.dp.toPx()
+    val imageSize = 92.dp
+    val imagePixel = imageSize.toPx()
+    val shape = remember { RoundedCornerShape(4.dp) }
 
     Column(
         modifier = Modifier
             .clickable { onClick() }
-            .width(92.dp)
+            .width(imageSize)
     ) {
         Box(modifier = Modifier) {
             AsyncImageWithPreview(
                 modifier = Modifier
-                    .size(92.dp)
-                    .clip(RoundedCornerShape(4.dp)),
+                    .size(imageSize)
+                    .clip(shape),
                 imageUrl = song.getImageUrl(imagePixel),
                 previewImage = painterResource(id = R.drawable.img_placeholder_album_cover),
-                imageOverrideSize = 92.dp,
-                loadingContent = loadingContent,
+                imageOverrideSize = imageSize,
+                loadingContent = {
+                    loadingContent?.invoke() ?: ShimmerSkeleton(
+                        modifier = Modifier
+                            .size(imageSize)
+                            .clip(shape)
+                    )
+                },
             )
 
             Box(

--- a/domain/src/main/kotlin/model/community/Post.kt
+++ b/domain/src/main/kotlin/model/community/Post.kt
@@ -13,6 +13,7 @@ import model.user.User
  * @property songList 게시글에 포함된 음악 리스트
  */
 data class Post(
+    val id: Int = -1,
     val title: String,
     val content: String,
     val author: User,

--- a/domain/src/main/kotlin/repository/post/PostRepository.kt
+++ b/domain/src/main/kotlin/repository/post/PostRepository.kt
@@ -5,5 +5,6 @@ import model.community.Post
 
 interface PostRepository {
 
+    fun getPosts(): FlowResult<List<Post>>
     fun addPost(post: Post): FlowResult<Unit>
 }

--- a/feature/community/src/main/kotlin/com/wepli/community/main/CommunityScreen.kt
+++ b/feature/community/src/main/kotlin/com/wepli/community/main/CommunityScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
@@ -28,6 +27,7 @@ import com.wepli.designsystem.R
 import com.wepli.shared.feature.uimodel.user.UserUiData
 import com.wepli.shared.feature.uimodel.community.PostUiData
 import common.WepliSpacer
+import org.orbitmvi.orbit.compose.collectAsState
 import theme.WepliTheme
 
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
@@ -38,7 +38,7 @@ fun CommunityScreen(
     navOnCommunityDetail: (PostUiData) -> Unit = {},
     navOnCommunityWrite: () -> Unit = {},
 ) {
-    val state by viewModel.state.collectAsState()
+    val state by viewModel.collectAsState()
     val storyUsers: List<UserUiData> by rememberUpdatedState(newValue = state.storyUsers)
     val posts: List<PostUiData> by rememberUpdatedState(newValue = state.posts)
 

--- a/feature/community/src/main/kotlin/com/wepli/community/main/CommunityViewModel.kt
+++ b/feature/community/src/main/kotlin/com/wepli/community/main/CommunityViewModel.kt
@@ -1,38 +1,37 @@
 package com.wepli.community.main
 
 import android.util.Log
-import base.BaseViewModel
-import com.wepli.community.main.state.CommunityMainState
+import base.BaseMviViewModel
+import com.wepli.community.main.mvi.CommunityMainUiState
+import com.wepli.community.write.mvi.CommunityWriteEffect
+import com.wepli.community.write.mvi.CommunityWriteIntent
 import com.wepli.core.kotlin.suspendCollectResult
 import com.wepli.shared.feature.mock.userMockData
 import com.wepli.shared.feature.uimodel.community.PostUiData
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.flowOn
-import kotlinx.coroutines.flow.update
 import repository.post.PostRepository
 import javax.inject.Inject
 
 @HiltViewModel
 class CommunityViewModel @Inject constructor(
     private val postRepository: PostRepository,
-) : BaseViewModel() {
-
-    private val _state = MutableStateFlow(CommunityMainState())
-    val state: StateFlow<CommunityMainState> = _state.asStateFlow()
+) : BaseMviViewModel<CommunityMainUiState, CommunityWriteEffect, CommunityWriteIntent>(
+    initialState = CommunityMainUiState()
+) {
 
     init {
         loadStoryUsers()
         loadPosts()
     }
 
-    private fun loadStoryUsers() = launchWithHandler {
-        _state.update {
-            it.copy(storyUsers = userMockData)
-        }
+    override fun processIntent(intent: CommunityWriteIntent) {
+        // TODO("Not yet implemented")
+    }
+
+    private fun loadStoryUsers() {
+        updateState { copy(storyUsers = userMockData) }
     }
 
     private fun loadPosts() = launchWithHandler {
@@ -41,8 +40,8 @@ class CommunityViewModel @Inject constructor(
             .suspendCollectResult(
                 onSuccess = { posts ->
                     Log.d("CommunityViewModel", "loadPosts: $posts")
-                    _state.update {
-                        it.copy(posts = posts.map { PostUiData.fromDomain(it) })
+                    updateState {
+                        copy(posts = posts.map { PostUiData.fromDomain(it) })
                     }
                 },
                 onFailure = {

--- a/feature/community/src/main/kotlin/com/wepli/community/main/CommunityViewModel.kt
+++ b/feature/community/src/main/kotlin/com/wepli/community/main/CommunityViewModel.kt
@@ -1,18 +1,25 @@
 package com.wepli.community.main
 
+import android.util.Log
 import base.BaseViewModel
 import com.wepli.community.main.state.CommunityMainState
-import com.wepli.shared.feature.mock.postMockData
+import com.wepli.core.kotlin.suspendCollectResult
 import com.wepli.shared.feature.mock.userMockData
+import com.wepli.shared.feature.uimodel.community.PostUiData
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.update
+import repository.post.PostRepository
 import javax.inject.Inject
 
 @HiltViewModel
-class CommunityViewModel @Inject constructor() : BaseViewModel() {
+class CommunityViewModel @Inject constructor(
+    private val postRepository: PostRepository,
+) : BaseViewModel() {
 
     private val _state = MutableStateFlow(CommunityMainState())
     val state: StateFlow<CommunityMainState> = _state.asStateFlow()
@@ -29,10 +36,18 @@ class CommunityViewModel @Inject constructor() : BaseViewModel() {
     }
 
     private fun loadPosts() = launchWithHandler {
-        val posts = List(100) { postMockData }.flatten().shuffled()
-
-        _state.update {
-            it.copy(posts = posts)
-        }
+        postRepository.getPosts()
+            .flowOn(Dispatchers.IO)
+            .suspendCollectResult(
+                onSuccess = { posts ->
+                    Log.d("CommunityViewModel", "loadPosts: $posts")
+                    _state.update {
+                        it.copy(posts = posts.map { PostUiData.fromDomain(it) })
+                    }
+                },
+                onFailure = {
+                    Log.e("CommunityViewModel", "loadPosts: $it")
+                }
+            )
     }
 }

--- a/feature/community/src/main/kotlin/com/wepli/community/main/mvi/CommunityMainMvi.kt
+++ b/feature/community/src/main/kotlin/com/wepli/community/main/mvi/CommunityMainMvi.kt
@@ -1,0 +1,16 @@
+package com.wepli.community.main.mvi
+
+import base.Intent
+import base.SideEffect
+import base.UiState
+import com.wepli.shared.feature.uimodel.community.PostUiData
+import com.wepli.shared.feature.uimodel.user.UserUiData
+
+data class CommunityMainUiState(
+    val storyUsers: List<UserUiData> = emptyList(),
+    val posts: List<PostUiData> = emptyList(),
+) : UiState
+
+interface CommunityMainEffect : SideEffect
+
+interface CommunityMainIntent : Intent

--- a/feature/community/src/main/kotlin/com/wepli/community/main/mvi/CommunityMainMvi.kt
+++ b/feature/community/src/main/kotlin/com/wepli/community/main/mvi/CommunityMainMvi.kt
@@ -15,4 +15,6 @@ interface CommunityMainEffect : SideEffect {
     data object ErrorLoadPosts : CommunityMainEffect
 }
 
-interface CommunityMainIntent : Intent
+interface CommunityMainIntent : Intent {
+    object LoadPosts : CommunityMainIntent
+}

--- a/feature/community/src/main/kotlin/com/wepli/community/main/mvi/CommunityMainMvi.kt
+++ b/feature/community/src/main/kotlin/com/wepli/community/main/mvi/CommunityMainMvi.kt
@@ -11,6 +11,8 @@ data class CommunityMainUiState(
     val posts: List<PostUiData> = emptyList(),
 ) : UiState
 
-interface CommunityMainEffect : SideEffect
+interface CommunityMainEffect : SideEffect {
+    data object ErrorLoadPosts : CommunityMainEffect
+}
 
 interface CommunityMainIntent : Intent

--- a/feature/community/src/main/kotlin/com/wepli/community/main/screen/CommunityScreen.kt
+++ b/feature/community/src/main/kotlin/com/wepli/community/main/screen/CommunityScreen.kt
@@ -23,23 +23,40 @@ import appbar.AppBarIconType
 import appbar.WepliAppBar
 import com.wepli.community.component.PostItem
 import com.wepli.community.component.WePLiStoryLayout
+import com.wepli.community.main.mvi.CommunityMainUiState
 import com.wepli.community.main.viewmodel.CommunityViewModel
 import com.wepli.designsystem.R
+import com.wepli.shared.feature.mock.postMockData
+import com.wepli.shared.feature.mock.userMockData
 import com.wepli.shared.feature.uimodel.user.UserUiData
 import com.wepli.shared.feature.uimodel.community.PostUiData
 import common.WepliSpacer
 import org.orbitmvi.orbit.compose.collectAsState
 import theme.WepliTheme
 
+@Composable
+fun CommunityMainScreenRoute(
+    navOnCommunityDetail: (PostUiData) -> Unit,
+    navOnCommunityWrite: () -> Unit,
+) {
+    val viewModel: CommunityViewModel = hiltViewModel()
+    val state: CommunityMainUiState by viewModel.collectAsState()
+
+    CommunityScreen(
+        state = state,
+        navOnCommunityDetail = navOnCommunityDetail,
+        navOnCommunityWrite = navOnCommunityWrite,
+    )
+}
+
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CommunityScreen(
-    viewModel: CommunityViewModel = hiltViewModel(),
+    state: CommunityMainUiState,
     navOnCommunityDetail: (PostUiData) -> Unit = {},
     navOnCommunityWrite: () -> Unit = {},
 ) {
-    val state by viewModel.collectAsState()
     val storyUsers: List<UserUiData> by rememberUpdatedState(newValue = state.storyUsers)
     val posts: List<PostUiData> by rememberUpdatedState(newValue = state.posts)
 
@@ -102,5 +119,10 @@ fun PostWritingButton(
 @Preview
 @Composable
 fun CommunityScreenPreview() {
-    CommunityScreen()
+    CommunityScreen(
+        state = CommunityMainUiState(
+            storyUsers = userMockData,
+            posts = postMockData,
+        ),
+    )
 }

--- a/feature/community/src/main/kotlin/com/wepli/community/main/screen/CommunityScreen.kt
+++ b/feature/community/src/main/kotlin/com/wepli/community/main/screen/CommunityScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
@@ -28,6 +29,7 @@ import appbar.WepliAppBar
 import com.wepli.community.component.PostItem
 import com.wepli.community.component.WePLiStoryLayout
 import com.wepli.community.main.mvi.CommunityMainEffect
+import com.wepli.community.main.mvi.CommunityMainIntent
 import com.wepli.community.main.mvi.CommunityMainUiState
 import com.wepli.community.main.viewmodel.CommunityViewModel
 import com.wepli.designsystem.R
@@ -42,6 +44,7 @@ import theme.WepliTheme
 
 @Composable
 fun CommunityMainScreenRoute(
+    needRefresh: Boolean,
     navOnCommunityDetail: (PostUiData) -> Unit,
     navOnCommunityWrite: () -> Unit,
 ) {
@@ -54,6 +57,12 @@ fun CommunityMainScreenRoute(
             is CommunityMainEffect.ErrorLoadPosts -> {
                 Toast.makeText(context, "게시글 조회에 실패했습니다.", Toast.LENGTH_SHORT).show()
             }
+        }
+    }
+
+    LaunchedEffect(needRefresh) {
+        if (needRefresh) {
+            viewModel.processIntent(CommunityMainIntent.LoadPosts)
         }
     }
 

--- a/feature/community/src/main/kotlin/com/wepli/community/main/screen/CommunityScreen.kt
+++ b/feature/community/src/main/kotlin/com/wepli/community/main/screen/CommunityScreen.kt
@@ -1,4 +1,4 @@
-package com.wepli.community.main
+package com.wepli.community.main.screen
 
 import android.annotation.SuppressLint
 import androidx.compose.foundation.Image
@@ -23,6 +23,7 @@ import appbar.AppBarIconType
 import appbar.WepliAppBar
 import com.wepli.community.component.PostItem
 import com.wepli.community.component.WePLiStoryLayout
+import com.wepli.community.main.viewmodel.CommunityViewModel
 import com.wepli.designsystem.R
 import com.wepli.shared.feature.uimodel.user.UserUiData
 import com.wepli.shared.feature.uimodel.community.PostUiData

--- a/feature/community/src/main/kotlin/com/wepli/community/main/screen/CommunityScreen.kt
+++ b/feature/community/src/main/kotlin/com/wepli/community/main/screen/CommunityScreen.kt
@@ -1,6 +1,7 @@
 package com.wepli.community.main.screen
 
 import android.annotation.SuppressLint
+import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
@@ -14,6 +15,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -23,6 +25,7 @@ import appbar.AppBarIconType
 import appbar.WepliAppBar
 import com.wepli.community.component.PostItem
 import com.wepli.community.component.WePLiStoryLayout
+import com.wepli.community.main.mvi.CommunityMainEffect
 import com.wepli.community.main.mvi.CommunityMainUiState
 import com.wepli.community.main.viewmodel.CommunityViewModel
 import com.wepli.designsystem.R
@@ -32,6 +35,7 @@ import com.wepli.shared.feature.uimodel.user.UserUiData
 import com.wepli.shared.feature.uimodel.community.PostUiData
 import common.WepliSpacer
 import org.orbitmvi.orbit.compose.collectAsState
+import org.orbitmvi.orbit.compose.collectSideEffect
 import theme.WepliTheme
 
 @Composable
@@ -41,6 +45,15 @@ fun CommunityMainScreenRoute(
 ) {
     val viewModel: CommunityViewModel = hiltViewModel()
     val state: CommunityMainUiState by viewModel.collectAsState()
+    val context = LocalContext.current
+
+    viewModel.collectSideEffect {
+        when (it) {
+            is CommunityMainEffect.ErrorLoadPosts -> {
+                Toast.makeText(context, "게시글 조회에 실패했습니다.", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
 
     CommunityScreen(
         state = state,

--- a/feature/community/src/main/kotlin/com/wepli/community/main/screen/CommunityScreen.kt
+++ b/feature/community/src/main/kotlin/com/wepli/community/main/screen/CommunityScreen.kt
@@ -5,6 +5,7 @@ import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -13,6 +14,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -91,8 +93,11 @@ fun CommunityScreen(
             )
         },
     ) { paddingValues ->
+        val bottomPadding = remember { paddingValues.calculateBottomPadding() * 2 }
+
         LazyColumn(
             modifier = Modifier.padding(paddingValues),
+            contentPadding = PaddingValues(bottom = bottomPadding),
         ) {
             item { WePLiStoryLayout(users = storyUsers) }
 

--- a/feature/community/src/main/kotlin/com/wepli/community/main/state/CommunityMainState.kt
+++ b/feature/community/src/main/kotlin/com/wepli/community/main/state/CommunityMainState.kt
@@ -1,9 +1,0 @@
-package com.wepli.community.main.state
-
-import com.wepli.shared.feature.uimodel.community.PostUiData
-import com.wepli.shared.feature.uimodel.user.UserUiData
-
-data class CommunityMainState(
-    val storyUsers: List<UserUiData> = emptyList(),
-    val posts: List<PostUiData> = emptyList(),
-)

--- a/feature/community/src/main/kotlin/com/wepli/community/main/viewmodel/CommunityViewModel.kt
+++ b/feature/community/src/main/kotlin/com/wepli/community/main/viewmodel/CommunityViewModel.kt
@@ -27,7 +27,9 @@ class CommunityViewModel @Inject constructor(
     }
 
     override fun processIntent(intent: CommunityMainIntent) {
-        // TODO("Not yet implemented")
+        when (intent) {
+            is CommunityMainIntent.LoadPosts -> loadPosts()
+        }
     }
 
     private fun loadStoryUsers() {

--- a/feature/community/src/main/kotlin/com/wepli/community/main/viewmodel/CommunityViewModel.kt
+++ b/feature/community/src/main/kotlin/com/wepli/community/main/viewmodel/CommunityViewModel.kt
@@ -2,9 +2,9 @@ package com.wepli.community.main.viewmodel
 
 import android.util.Log
 import base.BaseMviViewModel
+import com.wepli.community.main.mvi.CommunityMainEffect
+import com.wepli.community.main.mvi.CommunityMainIntent
 import com.wepli.community.main.mvi.CommunityMainUiState
-import com.wepli.community.write.mvi.CommunityWriteEffect
-import com.wepli.community.write.mvi.CommunityWriteIntent
 import com.wepli.core.kotlin.suspendCollectResult
 import com.wepli.shared.feature.mock.userMockData
 import com.wepli.shared.feature.uimodel.community.PostUiData
@@ -17,7 +17,7 @@ import javax.inject.Inject
 @HiltViewModel
 class CommunityViewModel @Inject constructor(
     private val postRepository: PostRepository,
-) : BaseMviViewModel<CommunityMainUiState, CommunityWriteEffect, CommunityWriteIntent>(
+) : BaseMviViewModel<CommunityMainUiState, CommunityMainEffect, CommunityMainIntent>(
     initialState = CommunityMainUiState()
 ) {
 
@@ -26,7 +26,7 @@ class CommunityViewModel @Inject constructor(
         loadPosts()
     }
 
-    override fun processIntent(intent: CommunityWriteIntent) {
+    override fun processIntent(intent: CommunityMainIntent) {
         // TODO("Not yet implemented")
     }
 

--- a/feature/community/src/main/kotlin/com/wepli/community/main/viewmodel/CommunityViewModel.kt
+++ b/feature/community/src/main/kotlin/com/wepli/community/main/viewmodel/CommunityViewModel.kt
@@ -46,6 +46,7 @@ class CommunityViewModel @Inject constructor(
                 },
                 onFailure = {
                     Log.e("CommunityViewModel", "loadPosts: $it")
+                    postSideEffect { CommunityMainEffect.ErrorLoadPosts }
                 }
             )
     }

--- a/feature/community/src/main/kotlin/com/wepli/community/main/viewmodel/CommunityViewModel.kt
+++ b/feature/community/src/main/kotlin/com/wepli/community/main/viewmodel/CommunityViewModel.kt
@@ -1,4 +1,4 @@
-package com.wepli.community.main
+package com.wepli.community.main.viewmodel
 
 import android.util.Log
 import base.BaseMviViewModel

--- a/feature/community/src/main/kotlin/com/wepli/community/main/viewmodel/CommunityViewModel.kt
+++ b/feature/community/src/main/kotlin/com/wepli/community/main/viewmodel/CommunityViewModel.kt
@@ -41,13 +41,11 @@ class CommunityViewModel @Inject constructor(
             .flowOn(Dispatchers.IO)
             .suspendCollectResult(
                 onSuccess = { posts ->
-                    Log.d("CommunityViewModel", "loadPosts: $posts")
                     updateState {
                         copy(posts = posts.map { PostUiData.fromDomain(it) })
                     }
                 },
                 onFailure = {
-                    Log.e("CommunityViewModel", "loadPosts: $it")
                     postSideEffect { CommunityMainEffect.ErrorLoadPosts }
                 }
             )

--- a/feature/community/src/main/kotlin/com/wepli/community/navigation/CommunityNavigation.kt
+++ b/feature/community/src/main/kotlin/com/wepli/community/navigation/CommunityNavigation.kt
@@ -10,6 +10,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import com.wepli.community.detail.CommunityDetailScreen
 import com.wepli.community.detail.CommunityDetailViewModel
+import com.wepli.community.main.screen.CommunityMainScreenRoute
 import com.wepli.community.main.screen.CommunityScreen
 import com.wepli.community.write.screen.CommunityWriteScreenRoute
 import com.wepli.navigator.extras.Extras
@@ -35,7 +36,7 @@ fun NavGraphBuilder.communityMainGraph(
     navOnCommunityWrite: () -> Unit
 ) {
     composable(CommunityRoute.Home.route) {
-        CommunityScreen(
+        CommunityMainScreenRoute(
             navOnCommunityDetail = { post -> navOnCommunityDetail(post) },
             navOnCommunityWrite = { navOnCommunityWrite() }
         )

--- a/feature/community/src/main/kotlin/com/wepli/community/navigation/CommunityNavigation.kt
+++ b/feature/community/src/main/kotlin/com/wepli/community/navigation/CommunityNavigation.kt
@@ -11,7 +11,6 @@ import androidx.navigation.navArgument
 import com.wepli.community.detail.CommunityDetailScreen
 import com.wepli.community.detail.CommunityDetailViewModel
 import com.wepli.community.main.screen.CommunityMainScreenRoute
-import com.wepli.community.main.screen.CommunityScreen
 import com.wepli.community.write.screen.CommunityWriteScreenRoute
 import com.wepli.navigator.extras.Extras
 import com.wepli.navigator.feature.community.CommunityRoute
@@ -30,13 +29,21 @@ fun NavController.navigateToCommunityWrite() {
     navigate(CommunityRoute.Write.route)
 }
 
+fun NavController.navigateToBackAndPostRefresh() {
+    previousBackStackEntry?.savedStateHandle?.set(Extras.COMMUNITY_NEED_REFRESH_POST, true)
+    navigateUp()
+}
+
 // Graph - 도착 지점(화면)을 정의
 fun NavGraphBuilder.communityMainGraph(
     navOnCommunityDetail: (PostUiData) -> Unit,
     navOnCommunityWrite: () -> Unit
 ) {
     composable(CommunityRoute.Home.route) {
+        val needRefresh = it.savedStateHandle.remove<Boolean>(Extras.COMMUNITY_NEED_REFRESH_POST) ?: false
+
         CommunityMainScreenRoute(
+            needRefresh = needRefresh,
             navOnCommunityDetail = { post -> navOnCommunityDetail(post) },
             navOnCommunityWrite = { navOnCommunityWrite() }
         )
@@ -67,11 +74,12 @@ fun NavGraphBuilder.communityDetailGraph(
 
 fun NavGraphBuilder.communityWriteGraph(
     navOnBack: () -> Unit,
-    navOnSearchDetail: () -> Unit
+    navOnBackAndPostRefresh: () -> Unit,
+    navOnSearchDetail: () -> Unit,
 ) {
     composable(CommunityRoute.Write.route) {
         val selectedSongs: List<SongUiData>? = it.savedStateHandle.remove<List<SongUiData>>(Extras.SELECTED_SONGS)
 
-        CommunityWriteScreenRoute(selectedSongs, navOnBack, navOnSearchDetail)
+        CommunityWriteScreenRoute(selectedSongs, navOnBack, navOnBackAndPostRefresh, navOnSearchDetail)
     }
 }

--- a/feature/community/src/main/kotlin/com/wepli/community/navigation/CommunityNavigation.kt
+++ b/feature/community/src/main/kotlin/com/wepli/community/navigation/CommunityNavigation.kt
@@ -10,7 +10,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import com.wepli.community.detail.CommunityDetailScreen
 import com.wepli.community.detail.CommunityDetailViewModel
-import com.wepli.community.main.CommunityScreen
+import com.wepli.community.main.screen.CommunityScreen
 import com.wepli.community.write.screen.CommunityWriteScreenRoute
 import com.wepli.navigator.extras.Extras
 import com.wepli.navigator.feature.community.CommunityRoute

--- a/feature/community/src/main/kotlin/com/wepli/community/write/screen/CommunityWriteScreen.kt
+++ b/feature/community/src/main/kotlin/com/wepli/community/write/screen/CommunityWriteScreen.kt
@@ -46,7 +46,6 @@ import com.wepli.community.write.viewmodel.CommunityWriteViewModel
 import com.wepli.designsystem.R
 import com.wepli.shared.feature.mock.songMockData
 import com.wepli.uimodel.music.SongUiData
-import common.ShimmerSkeleton
 import component.bottomsheet.WepliBottomSheetType
 import component.bottomsheet.WepliBottomSheet
 import compose.MeasuredHeightContainer
@@ -61,6 +60,7 @@ import theme.WepliTheme
 fun CommunityWriteScreenRoute(
     selectedSongs: List<SongUiData>?,
     navOnBack: () -> Unit,
+    navOnBackAndPostRefresh: () -> Unit,
     navOnSearchDetail: () -> Unit
 ) {
     val viewModel: CommunityWriteViewModel = hiltViewModel()
@@ -71,7 +71,7 @@ fun CommunityWriteScreenRoute(
         when (it) {
             is CommunityWriteEffect.SuccessAddPost -> {
                 Toast.makeText(context, "게시글 작성을 완료했습니다.", Toast.LENGTH_SHORT).show()
-                navOnBack()
+                navOnBackAndPostRefresh()
             }
             is CommunityWriteEffect.FailedAddPost -> {
                 Toast.makeText(context, "게시글 작성에 실패했습니다.", Toast.LENGTH_SHORT).show()

--- a/feature/community/src/main/kotlin/com/wepli/community/write/screen/CommunityWriteScreen.kt
+++ b/feature/community/src/main/kotlin/com/wepli/community/write/screen/CommunityWriteScreen.kt
@@ -254,13 +254,6 @@ fun SelectedSongLayout(
                     SongItem(
                         song = song,
                         onClick = { sendAction(CommunityWriteIntent.RemoveSelectedSongs(song)) },
-                        loadingContent = {
-                            ShimmerSkeleton(
-                                modifier = Modifier
-                                    .size(92.dp)
-                                    .clip(RoundedCornerShape(4.dp)),
-                            )
-                        }
                     )
                 }
 

--- a/shared/feature/src/main/java/com/wepli/shared/feature/mock/PostMockData.kt
+++ b/shared/feature/src/main/java/com/wepli/shared/feature/mock/PostMockData.kt
@@ -4,31 +4,35 @@ import com.wepli.shared.feature.uimodel.community.PostUiData
 
 val postMockData = listOf(
     PostUiData(
+        id = 1,
         title = "밤새면서 들을 수 있는 플리",
         content = "여러분은 코딩할 때 어떤 곡을 듣나요?! 댓글로 알려주세요!\n제가 주로 듣는 곡들을 플레이리스트로 만들어봤어요~\n\n같이 들으면 좋을만한 노래 추천해주세요!",
-        author = "dlwlrma",
-        profileImg = "https://image.bugsm.co.kr/artist/images/1000/800491/80049126_068.jpg?version=301040&d=20210325154659",
+        author = userMockData[0].nickname,
+        profileImg = userMockData[0].profileImgUrl,
         songList = songMockData
     ),
     PostUiData(
+        id = 2,
         title = "요즘 최애 노래",
         content = "케이윌이랑 매드클라운 조합 너무 좋아요ㅠㅠ\n가볍게 듣기에도 좋고 은근 밝은 느낌이라서 더 좋아요\n\n다들 한 번씩 들어보세요~~~",
-        author = "yoonha",
-        profileImg = "https://image.bugsm.co.kr/artist/images/1000/800100/80010025_100.jpg?version=332223&d=20220330143136",
+        author = userMockData[1].nickname,
+        profileImg = userMockData[1].profileImgUrl,
         songList = songMockData.shuffled().take(1)
     ),
     PostUiData(
+        id = 3,
         title = "이것도 들어봐ㅏㅏ",
         content = "이것도 들어봐바\n봄이면 꼭 들어야 돼 나만 들을 순 없어\n\n빨리 다들 한 번씩 듣고 댓글로 감상평 남겨ㅡㅡ",
-        author = "yoonha",
-        profileImg = "https://image.bugsm.co.kr/artist/images/1000/800100/80010025_100.jpg?version=332223&d=20220330143136",
+        author = userMockData[2].nickname,
+        profileImg = userMockData[2].profileImgUrl,
         songList = songMockData.shuffled().take(1)
     ),
     PostUiData(
+        id = 4,
         title = "너무 심심해요",
         content = "주말에 하루종일 아무것도 할 게 없어서 심심하네요\n스피커도 새로 샀는데 들을 노래도 없고...\n\n혼자서 심심할 때 듣기 좋은 노래 추천 부탁드려요 :)",
-        author = "roykim_official",
-        profileImg = "https://image.bugsm.co.kr/artist/images/1000/801377/80137715.jpg?version=112079&d=20240304183844",
+        author = userMockData[3].nickname,
+        profileImg = userMockData[3].profileImgUrl,
         songList = emptyList()
     )
 )

--- a/shared/feature/src/main/java/com/wepli/shared/feature/uimodel/community/PostUiData.kt
+++ b/shared/feature/src/main/java/com/wepli/shared/feature/uimodel/community/PostUiData.kt
@@ -16,6 +16,7 @@ import model.community.Post
  */
 @Parcelize
 data class PostUiData(
+    val id: Int,
     val title: String,
     val content: String,
     val author: String,
@@ -23,11 +24,12 @@ data class PostUiData(
     val songList: List<SongUiData>
 ) : UiModel {
 
-    constructor() : this("", "", "", "", emptyList())
+    constructor() : this(-1, "", "", "", "", emptyList())
 
     companion object : UiModelMapper<Post, PostUiData> {
         override fun fromDomain(domainModel: Post): PostUiData {
             return PostUiData(
+                id = domainModel.id,
                 title = domainModel.title,
                 content = domainModel.content,
                 author = domainModel.author.nickname,


### PR DESCRIPTION
### 변경사항
- 게시글 조회 로직 추가
- 게시글 조회 실패시 예외 처리
- BaseMviViewModel postSideEffect 함수 추가
   - updateState, postSideEffect 메소드에 @OrbitDsl 어노테이션 추가
   - 호출부에서도 Orbit 관련 메소드임을 인지시키기 위함

**supabase 관련 변경 사항**
- Postgre의 [Json Aggregation](https://www.postgresql.org/docs/9.5/functions-aggregate.html)을 이용한 계층형 View 생성

![image](https://github.com/user-attachments/assets/bbfbee7c-e3cd-45f6-8766-c161bfe569cb)

### 추후 할 일
- 페이징 적용
- 게시글 조회 실패 시 에러 페이지 적용

### 스크린샷

| 게시글 목록 | 게시글 조회 실패 |
|-----------|----------------|
| <img width="395" alt="image" src="https://github.com/user-attachments/assets/e1e077e6-13fa-45e4-84b3-09c3bbf7a5cf" /> | ![image](https://github.com/user-attachments/assets/812fb62d-3599-49cd-a00f-7e5e6651b144) |