### PR TITLE
[Feature/add_youtube_music_video] 노래 정보 UI에 뮤직비디오 추가

### DIFF
--- a/core/resources/src/main/res/drawable/ic_arrow_expand.xml
+++ b/core/resources/src/main/res/drawable/ic_arrow_expand.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="20"
+    android:viewportHeight="20">
+  <path
+      android:pathData="M11.837,3.333H16.665M16.665,3.333V8.161M16.665,3.333L11.033,8.966M8.16,16.667H3.332M3.332,16.667V11.839M3.332,16.667L8.965,11.035"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#C2C2C2"
+      android:strokeLineCap="round"/>
+</vector>

--- a/core/resources/src/main/res/drawable/ic_arrow_minimize.xml
+++ b/core/resources/src/main/res/drawable/ic_arrow_minimize.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="21dp"
+    android:viewportWidth="20"
+    android:viewportHeight="21">
+  <path
+      android:pathData="M2.966,11.603L8.759,11.603M8.759,11.603L8.759,17.396M8.759,11.603L2,18.362M17.033,9.12L11.24,9.12M11.24,9.12V3.327M11.24,9.12L17.999,2.362"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#B5B5C0"
+      android:strokeLineCap="round"/>
+</vector>

--- a/data/src/main/kotlin/com/wepli/data/di/RetrofitModule.kt
+++ b/data/src/main/kotlin/com/wepli/data/di/RetrofitModule.kt
@@ -7,6 +7,7 @@ import com.wepli.data.di.qualifier.AppleMusicOkHttpClient
 import com.wepli.data.di.qualifier.AppleMusicRetrofit
 import com.wepli.data.di.qualifier.BaseOkHttpClient
 import com.wepli.data.di.qualifier.BaseRetrofit
+import com.wepli.data.di.qualifier.YoutubeRetrofit
 import com.wepli.data.network.baseurl.BaseUrl
 import com.wepli.data.network.calladapter.FlowCallAdapterFactory
 import com.wepli.data.network.interceptor.DebugApiLogInterceptor
@@ -126,6 +127,23 @@ object RetrofitModule {
 
         return Retrofit.Builder()
             .baseUrl(BaseUrl.APPLE_MUSIC.url)
+            .client(httpClient)
+            .addConverterFactory(converterFactory)
+            .addCallAdapterFactory(FlowCallAdapterFactory.create())
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    @YoutubeRetrofit
+    fun provideYoutubeRetrofit(
+        @BaseOkHttpClient httpClient: OkHttpClient
+    ): Retrofit {
+        val contentType = "application/json".toMediaType()
+        val converterFactory = json.asConverterFactory(contentType)
+
+        return Retrofit.Builder()
+            .baseUrl(BaseUrl.YOUTUBE.url)
             .client(httpClient)
             .addConverterFactory(converterFactory)
             .addCallAdapterFactory(FlowCallAdapterFactory.create())

--- a/data/src/main/kotlin/com/wepli/data/di/ServiceModule.kt
+++ b/data/src/main/kotlin/com/wepli/data/di/ServiceModule.kt
@@ -5,8 +5,10 @@ import com.wepli.data.artist.ArtistApi
 import com.wepli.data.chart.ChartApi
 import com.wepli.data.di.qualifier.AppleMusicRetrofit
 import com.wepli.data.di.qualifier.BaseRetrofit
+import com.wepli.data.di.qualifier.YoutubeRetrofit
 import com.wepli.data.playlist.PlaylistApi
 import com.wepli.data.relaylist.RelaylistApi
+import com.wepli.data.youtube.YoutubeApi
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -38,4 +40,8 @@ object ServiceModule {
     @Provides
     @Singleton
     fun provideAppleMusicService(@AppleMusicRetrofit retrofit: Retrofit): AppleMusicApi = retrofit.create(AppleMusicApi::class.java)
+
+    @Provides
+    @Singleton
+    fun provideYoutubeService(@YoutubeRetrofit retrofit: Retrofit): YoutubeApi = retrofit.create(YoutubeApi::class.java)
 }

--- a/data/src/main/kotlin/com/wepli/data/di/datasource/DataSourceModule.kt
+++ b/data/src/main/kotlin/com/wepli/data/di/datasource/DataSourceModule.kt
@@ -29,6 +29,9 @@ import com.wepli.data.supabase.bucket.datasource.SupabaseBucketDataSource
 import com.wepli.data.supabase.bucket.datasource.SupabaseBucketDataSourceImpl
 import com.wepli.data.user.datasource.UserSupabaseDataSource
 import com.wepli.data.user.datasource.UserSupabaseDataSourceImpl
+import com.wepli.data.youtube.datasource.remote.YoutubeRemoteDataSource
+import com.wepli.data.youtube.datasource.remote.YoutubeRemoteDataSourceImpl
+import com.wepli.data.youtube.repository.YoutubeRepositoryImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -61,6 +64,10 @@ interface DataSourceModule {
     @Binds
     @Singleton
     fun bindAppleMusicDataSource(appleMusicDataSourceImpl: AppleMusicDataSourceImpl): AppleMusicDataSource
+
+    @Binds
+    @Singleton
+    fun bindYoutubeDataSource(youtubeDataSourceImpl: YoutubeRemoteDataSourceImpl): YoutubeRemoteDataSource
 
     @Binds
     @Singleton

--- a/data/src/main/kotlin/com/wepli/data/di/qualifier/RetrofitQualifier.kt
+++ b/data/src/main/kotlin/com/wepli/data/di/qualifier/RetrofitQualifier.kt
@@ -10,3 +10,7 @@ annotation class BaseRetrofit
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 annotation class AppleMusicRetrofit
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class YoutubeRetrofit

--- a/data/src/main/kotlin/com/wepli/data/di/repository/RepositoryModule.kt
+++ b/data/src/main/kotlin/com/wepli/data/di/repository/RepositoryModule.kt
@@ -18,6 +18,8 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import debug.repository.DebugApiLogRepository
 import com.wepli.data.network.apilog.DebugApiLogRepositoryImpl
+import com.wepli.data.youtube.repository.YoutubeRepository
+import com.wepli.data.youtube.repository.YoutubeRepositoryImpl
 import model.recommend.repository.KeywordRepository
 import model.supabase.repository.SupabaseBucketRepository
 import repository.applemusic.AppleMusicRepository
@@ -67,6 +69,10 @@ interface RepositoryModule {
     @Binds
     @Singleton
     fun bindAppleMusicRepository(appleMusicRepositoryImpl: AppleMusicRepositoryImpl): AppleMusicRepository
+
+    @Binds
+    @Singleton
+    fun bindYoutubeRepository(youtubeRepositoryImpl: YoutubeRepositoryImpl): YoutubeRepository
 
     @Binds
     @Singleton

--- a/data/src/main/kotlin/com/wepli/data/di/repository/RepositoryModule.kt
+++ b/data/src/main/kotlin/com/wepli/data/di/repository/RepositoryModule.kt
@@ -10,7 +10,6 @@ import com.wepli.data.post.repository.PostRepositoryImpl
 import com.wepli.data.relaylist.repository.RelaylistRepositoryImpl
 import com.wepli.data.song.repository.SongRepository
 import com.wepli.data.song.repository.SongRepositoryImpl
-import com.wepli.data.supabase.bucket.repository.SupabaseBucketRepositoryImpl
 import com.wepli.data.user.UserRepositoryImpl
 import dagger.Binds
 import dagger.Module
@@ -18,10 +17,9 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import debug.repository.DebugApiLogRepository
 import com.wepli.data.network.apilog.DebugApiLogRepositoryImpl
-import com.wepli.data.youtube.repository.YoutubeRepository
+import repository.youtube.YoutubeRepository
 import com.wepli.data.youtube.repository.YoutubeRepositoryImpl
 import model.recommend.repository.KeywordRepository
-import model.supabase.repository.SupabaseBucketRepository
 import repository.applemusic.AppleMusicRepository
 import repository.artist.ArtistRepository
 import repository.playlist.PlaylistRepository

--- a/data/src/main/kotlin/com/wepli/data/network/baseurl/BaseUrl.kt
+++ b/data/src/main/kotlin/com/wepli/data/network/baseurl/BaseUrl.kt
@@ -5,7 +5,8 @@ import com.wepli.core.common.BuildConfig
 enum class BaseUrl(
     private val prodUrl: String,
     private val testUrl: String,
-    val value: String
+    val value: String,
+    val url: String = if (BuildConfig.DEBUG) testUrl else prodUrl
 ) {
     POSTMAN(
         prodUrl = BuildConfig.POSTMAN_URL,
@@ -22,12 +23,14 @@ enum class BaseUrl(
         testUrl = BuildConfig.SUPABASE_URL,
         value = "Supabase API"
     ),
+    YOUTUBE(
+        prodUrl = BuildConfig.YOUTUBE_API_URL,
+        testUrl = BuildConfig.YOUTUBE_API_URL,
+        value = "Youtube API"
+    ),
     UNKNOWN(
         prodUrl = "",
         testUrl = "",
         value = "Unknown API"
     );
-
-    val url: String
-        get() = if (BuildConfig.DEBUG) testUrl else prodUrl
 }

--- a/data/src/main/kotlin/com/wepli/data/youtube/YoutubeApi.kt
+++ b/data/src/main/kotlin/com/wepli/data/youtube/YoutubeApi.kt
@@ -1,0 +1,20 @@
+package com.wepli.data.youtube
+
+import com.wepli.core.common.BuildConfig
+import com.wepli.core.kotlin.flow.FlowResult
+import com.wepli.data.youtube.response.YoutubeVideoResponse
+import com.wepli.data.youtube.response.YoutubeDataWrapper
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface YoutubeApi {
+
+    @GET("search")
+    fun searchFromQuery(
+        @Query("q") searchQuery: String,
+        @Query("part") part: String,
+        @Query("type") type: String,
+        @Query("maxResults") maxResults: Int,
+        @Query("key") apiKey: String = BuildConfig.YOUTUBE_API_TOKEN,
+    ): FlowResult<YoutubeDataWrapper<YoutubeVideoResponse>>
+}

--- a/data/src/main/kotlin/com/wepli/data/youtube/datasource/remote/YoutubeRemoteDataSource.kt
+++ b/data/src/main/kotlin/com/wepli/data/youtube/datasource/remote/YoutubeRemoteDataSource.kt
@@ -1,0 +1,17 @@
+package com.wepli.data.youtube.datasource.remote
+
+import com.wepli.core.common.BuildConfig
+import com.wepli.core.kotlin.flow.FlowResult
+import com.wepli.data.youtube.response.YoutubeDataWrapper
+import com.wepli.data.youtube.response.YoutubeVideoResponse
+
+interface YoutubeRemoteDataSource {
+
+    fun searchFromQuery(
+        searchQuery: String,
+        part: String,
+        type: String,
+        maxResults: Int,
+        apiKey: String = BuildConfig.YOUTUBE_API_TOKEN,
+    ): FlowResult<YoutubeDataWrapper<YoutubeVideoResponse>>
+}

--- a/data/src/main/kotlin/com/wepli/data/youtube/datasource/remote/YoutubeRemoteDataSourceImpl.kt
+++ b/data/src/main/kotlin/com/wepli/data/youtube/datasource/remote/YoutubeRemoteDataSourceImpl.kt
@@ -1,0 +1,29 @@
+package com.wepli.data.youtube.datasource.remote
+
+
+import com.wepli.core.kotlin.flow.FlowResult
+import com.wepli.data.youtube.YoutubeApi
+import com.wepli.data.youtube.response.YoutubeDataWrapper
+import com.wepli.data.youtube.response.YoutubeVideoResponse
+import javax.inject.Inject
+
+class YoutubeRemoteDataSourceImpl @Inject constructor(
+    private val youtubeApi: YoutubeApi
+) : YoutubeRemoteDataSource {
+
+    override fun searchFromQuery(
+        searchQuery: String,
+        part: String,
+        type: String,
+        maxResults: Int,
+        apiKey: String
+    ): FlowResult<YoutubeDataWrapper<YoutubeVideoResponse>> {
+        return youtubeApi.searchFromQuery(
+            searchQuery = searchQuery,
+            part = part,
+            type = type,
+            maxResults = maxResults,
+            apiKey = apiKey,
+        )
+    }
+}

--- a/data/src/main/kotlin/com/wepli/data/youtube/repository/YoutubeRepository.kt
+++ b/data/src/main/kotlin/com/wepli/data/youtube/repository/YoutubeRepository.kt
@@ -1,0 +1,9 @@
+package com.wepli.data.youtube.repository
+
+import com.wepli.core.kotlin.flow.FlowResult
+import model.musicvideo.MusicVideo
+
+interface YoutubeRepository {
+
+    fun searchMusicVideo(searchQuery: String): FlowResult<MusicVideo>
+}

--- a/data/src/main/kotlin/com/wepli/data/youtube/repository/YoutubeRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/wepli/data/youtube/repository/YoutubeRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.wepli.data.network.toEntityResult
 import com.wepli.data.youtube.datasource.remote.YoutubeRemoteDataSource
 import com.wepli.data.youtube.response.toDomain
 import model.musicvideo.MusicVideo
+import repository.youtube.YoutubeRepository
 import javax.inject.Inject
 
 class YoutubeRepositoryImpl @Inject constructor(
@@ -18,7 +19,7 @@ class YoutubeRepositoryImpl @Inject constructor(
             type = "video",
             maxResults = 1,
         ).toEntityResult {
-            it.data.first().toDomain()
+            it.items.first().toDomain()
         }
     }
 }

--- a/data/src/main/kotlin/com/wepli/data/youtube/repository/YoutubeRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/wepli/data/youtube/repository/YoutubeRepositoryImpl.kt
@@ -12,14 +12,14 @@ class YoutubeRepositoryImpl @Inject constructor(
     private val youtubeRemoteDataSource: YoutubeRemoteDataSource
 ): YoutubeRepository {
 
-    override fun searchMusicVideo(searchQuery: String): FlowResult<MusicVideo> {
+    override fun searchMusicVideo(searchQuery: String): FlowResult<MusicVideo?> {
         return youtubeRemoteDataSource.searchFromQuery(
             searchQuery = searchQuery,
             part = "snippet",
             type = "video",
             maxResults = 1,
         ).toEntityResult {
-            it.items.first().toDomain()
+            it.items.firstOrNull()?.toDomain()
         }
     }
 }

--- a/data/src/main/kotlin/com/wepli/data/youtube/repository/YoutubeRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/wepli/data/youtube/repository/YoutubeRepositoryImpl.kt
@@ -1,0 +1,24 @@
+package com.wepli.data.youtube.repository
+
+import com.wepli.core.kotlin.flow.FlowResult
+import com.wepli.data.network.toEntityResult
+import com.wepli.data.youtube.datasource.remote.YoutubeRemoteDataSource
+import com.wepli.data.youtube.response.toDomain
+import model.musicvideo.MusicVideo
+import javax.inject.Inject
+
+class YoutubeRepositoryImpl @Inject constructor(
+    private val youtubeRemoteDataSource: YoutubeRemoteDataSource
+): YoutubeRepository {
+
+    override fun searchMusicVideo(searchQuery: String): FlowResult<MusicVideo> {
+        return youtubeRemoteDataSource.searchFromQuery(
+            searchQuery = searchQuery,
+            part = "snippet",
+            type = "video",
+            maxResults = 1,
+        ).toEntityResult {
+            it.data.first().toDomain()
+        }
+    }
+}

--- a/data/src/main/kotlin/com/wepli/data/youtube/response/YoutubeDataWrapper.kt
+++ b/data/src/main/kotlin/com/wepli/data/youtube/response/YoutubeDataWrapper.kt
@@ -1,6 +1,8 @@
 package com.wepli.data.youtube.response
 
-data class YoutubeDataWrapper<D>(
-    val data: List<D> = emptyList(),
-)
+import kotlinx.serialization.Serializable
 
+@Serializable
+data class YoutubeDataWrapper<D>(
+    val items: List<D> = emptyList(),
+)

--- a/data/src/main/kotlin/com/wepli/data/youtube/response/YoutubeDataWrapper.kt
+++ b/data/src/main/kotlin/com/wepli/data/youtube/response/YoutubeDataWrapper.kt
@@ -1,0 +1,6 @@
+package com.wepli.data.youtube.response
+
+data class YoutubeDataWrapper<D>(
+    val data: List<D> = emptyList(),
+)
+

--- a/data/src/main/kotlin/com/wepli/data/youtube/response/YoutubeVideoResponse.kt
+++ b/data/src/main/kotlin/com/wepli/data/youtube/response/YoutubeVideoResponse.kt
@@ -44,7 +44,7 @@ fun YoutubeVideoResponse.toDomain(): MusicVideo {
     return MusicVideo(
         id = id?.videoId.orEmpty(),
         title = snippet?.title.orEmpty(),
-        playtime = 0f,
+        channelTitle = snippet?.channelTitle.orEmpty(),
         thumbnail = snippet?.thumbnails?.high?.url.orEmpty()
     )
 }

--- a/data/src/main/kotlin/com/wepli/data/youtube/response/YoutubeVideoResponse.kt
+++ b/data/src/main/kotlin/com/wepli/data/youtube/response/YoutubeVideoResponse.kt
@@ -1,17 +1,21 @@
 package com.wepli.data.youtube.response
 
+import kotlinx.serialization.Serializable
 import model.musicvideo.MusicVideo
 
+@Serializable
 data class YoutubeVideoResponse(
     val id: VideoId? = null,
     val snippet: VideoSnippet? = null
 ) {
     // 비디오 ID 정보
+    @Serializable
     data class VideoId(
         val videoId: String? = null
     )
 
     // 비디오 상세 정보
+    @Serializable
     data class VideoSnippet(
         val title: String? = null,
         val description: String? = null,
@@ -21,11 +25,13 @@ data class YoutubeVideoResponse(
     )
 
     // 썸네일 정보
+    @Serializable
     data class VideoThumbnails(
         val default: Thumbnail? = null,
         val medium: Thumbnail? = null,
         val high: Thumbnail? = null
     ) {
+        @Serializable
         data class Thumbnail(
             val url: String? = null,
             val width: Int? = null,

--- a/data/src/main/kotlin/com/wepli/data/youtube/response/YoutubeVideoResponse.kt
+++ b/data/src/main/kotlin/com/wepli/data/youtube/response/YoutubeVideoResponse.kt
@@ -1,0 +1,44 @@
+package com.wepli.data.youtube.response
+
+import model.musicvideo.MusicVideo
+
+data class YoutubeVideoResponse(
+    val id: VideoId? = null,
+    val snippet: VideoSnippet? = null
+) {
+    // 비디오 ID 정보
+    data class VideoId(
+        val videoId: String? = null
+    )
+
+    // 비디오 상세 정보
+    data class VideoSnippet(
+        val title: String? = null,
+        val description: String? = null,
+        val channelTitle: String? = null,
+        val publishedAt: String? = null,
+        val thumbnails: VideoThumbnails? = null
+    )
+
+    // 썸네일 정보
+    data class VideoThumbnails(
+        val default: Thumbnail? = null,
+        val medium: Thumbnail? = null,
+        val high: Thumbnail? = null
+    ) {
+        data class Thumbnail(
+            val url: String? = null,
+            val width: Int? = null,
+            val height: Int? = null
+        )
+    }
+}
+
+fun YoutubeVideoResponse.toDomain(): MusicVideo {
+    return MusicVideo(
+        id = id?.videoId.orEmpty(),
+        title = snippet?.title.orEmpty(),
+        playtime = 0f,
+        thumbnail = snippet?.thumbnails?.high?.url.orEmpty()
+    )
+}

--- a/designsystem/build.gradle.kts
+++ b/designsystem/build.gradle.kts
@@ -15,4 +15,5 @@ dependencies {
     implementation(libs.coil)
     implementation(libs.blur.haze)
     implementation(libs.blur.haze.materials)
+    implementation(libs.youtube.player)
 }

--- a/designsystem/src/main/kotlin/component/youtube/YoutubeVideoPlayer.kt
+++ b/designsystem/src/main/kotlin/component/youtube/YoutubeVideoPlayer.kt
@@ -21,7 +21,6 @@ fun YoutubeVideoPlayer(
     forcePause: Boolean = false,
     needAutoPlay: Boolean = false,
     autoPlayStartSeconds: Float = 0f,
-    onDurationReady: ((Float) -> Unit)? = null,
     lifecycleOwner: LifecycleOwner = LocalLifecycleOwner.current,
     modifier: Modifier = Modifier
 ) {
@@ -50,10 +49,6 @@ fun YoutubeVideoPlayer(
                         } else {
                             player.cueVideo(videoId, 0f)
                         }
-                    }
-
-                    override fun onVideoDuration(youTubePlayer: YouTubePlayer, duration: Float) {
-                        onDurationReady?.invoke(duration)
                     }
                 })
             }

--- a/designsystem/src/main/kotlin/component/youtube/YoutubeVideoPlayer.kt
+++ b/designsystem/src/main/kotlin/component/youtube/YoutubeVideoPlayer.kt
@@ -26,7 +26,7 @@ fun YoutubeVideoPlayer(
 ) {
     var youTubePlayer: YouTubePlayer? by remember { mutableStateOf(null) }
 
-    LaunchedEffect(forcePause) {
+    LaunchedEffect(forcePause, youTubePlayer) {
         youTubePlayer?.let { player ->
             if (forcePause) {
                 player.pause()

--- a/designsystem/src/main/kotlin/component/youtube/YoutubeVideoPlayer.kt
+++ b/designsystem/src/main/kotlin/component/youtube/YoutubeVideoPlayer.kt
@@ -39,19 +39,20 @@ fun YoutubeVideoPlayer(
         factory = { context ->
             YouTubePlayerView(context).apply {
                 lifecycleOwner.lifecycle.addObserver(this)
-
-                addYouTubePlayerListener(object : AbstractYouTubePlayerListener() {
-                    override fun onReady(player: YouTubePlayer) {
-                        youTubePlayer = player
-
-                        if (needAutoPlay) {
-                            player.loadVideo(videoId, autoPlayStartSeconds)
-                        } else {
-                            player.cueVideo(videoId, 0f)
-                        }
-                    }
-                })
             }
+        },
+        update = { view ->
+            view.addYouTubePlayerListener(object : AbstractYouTubePlayerListener() {
+                override fun onReady(player: YouTubePlayer) {
+                    youTubePlayer = player
+
+                    if (needAutoPlay) {
+                        player.loadVideo(videoId, autoPlayStartSeconds)
+                    } else {
+                        player.cueVideo(videoId, 0f)
+                    }
+                }
+            })
         }
     )
 }

--- a/designsystem/src/main/kotlin/component/youtube/YoutubeVideoPlayer.kt
+++ b/designsystem/src/main/kotlin/component/youtube/YoutubeVideoPlayer.kt
@@ -1,0 +1,57 @@
+package component.youtube
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.lifecycle.LifecycleOwner
+import com.pierfrancescosoffritti.androidyoutubeplayer.core.player.YouTubePlayer
+import com.pierfrancescosoffritti.androidyoutubeplayer.core.player.listeners.AbstractYouTubePlayerListener
+import com.pierfrancescosoffritti.androidyoutubeplayer.core.player.views.YouTubePlayerView
+
+@Composable
+fun YoutubeVideoPlayer(
+    videoId: String,
+    forcePause: Boolean = false,
+    needAutoPlay: Boolean = false,
+    autoPlayStartSeconds: Float = 0f,
+    lifecycleOwner: LifecycleOwner = LocalLifecycleOwner.current,
+    modifier: Modifier = Modifier
+) {
+    var youTubePlayer: YouTubePlayer? by remember { mutableStateOf(null) }
+
+    LaunchedEffect(forcePause) {
+        youTubePlayer?.let { player ->
+            if (forcePause) {
+                player.pause()
+            }
+        }
+    }
+
+    AndroidView(
+        modifier = modifier.fillMaxWidth(),
+        factory = { context ->
+            YouTubePlayerView(context).apply {
+                lifecycleOwner.lifecycle.addObserver(this)
+
+                addYouTubePlayerListener(object : AbstractYouTubePlayerListener() {
+                    override fun onReady(player: YouTubePlayer) {
+                        youTubePlayer = player
+
+                        if (needAutoPlay) {
+                            player.loadVideo(videoId, autoPlayStartSeconds)
+                        } else {
+                            player.cueVideo(videoId, 0f)
+                        }
+                    }
+                })
+            }
+        }
+    )
+}

--- a/designsystem/src/main/kotlin/component/youtube/YoutubeVideoPlayer.kt
+++ b/designsystem/src/main/kotlin/component/youtube/YoutubeVideoPlayer.kt
@@ -21,6 +21,7 @@ fun YoutubeVideoPlayer(
     forcePause: Boolean = false,
     needAutoPlay: Boolean = false,
     autoPlayStartSeconds: Float = 0f,
+    onDurationReady: ((Float) -> Unit)? = null,
     lifecycleOwner: LifecycleOwner = LocalLifecycleOwner.current,
     modifier: Modifier = Modifier
 ) {
@@ -49,6 +50,10 @@ fun YoutubeVideoPlayer(
                         } else {
                             player.cueVideo(videoId, 0f)
                         }
+                    }
+
+                    override fun onVideoDuration(youTubePlayer: YouTubePlayer, duration: Float) {
+                        onDurationReady?.invoke(duration)
                     }
                 })
             }

--- a/domain/src/main/kotlin/model/musicvideo/MusicVideo.kt
+++ b/domain/src/main/kotlin/model/musicvideo/MusicVideo.kt
@@ -5,6 +5,6 @@ import common.DomainModel
 data class MusicVideo(
     val id: String,
     val title: String,
-    val playtime: Float,
+    val channelTitle: String,
     val thumbnail: String,
 ) : DomainModel

--- a/domain/src/main/kotlin/model/musicvideo/MusicVideo.kt
+++ b/domain/src/main/kotlin/model/musicvideo/MusicVideo.kt
@@ -3,8 +3,8 @@ package model.musicvideo
 import common.DomainModel
 
 data class MusicVideo(
-    private val id: String,
-    private val title: String,
-    private val playtime: Float,
-    private val thumbnail: String,
+    val id: String,
+    val title: String,
+    val playtime: Float,
+    val thumbnail: String,
 ) : DomainModel

--- a/domain/src/main/kotlin/model/musicvideo/MusicVideo.kt
+++ b/domain/src/main/kotlin/model/musicvideo/MusicVideo.kt
@@ -1,0 +1,10 @@
+package model.musicvideo
+
+import common.DomainModel
+
+data class MusicVideo(
+    private val id: String,
+    private val title: String,
+    private val playtime: Float,
+    private val thumbnail: String,
+) : DomainModel

--- a/domain/src/main/kotlin/repository/youtube/YoutubeRepository.kt
+++ b/domain/src/main/kotlin/repository/youtube/YoutubeRepository.kt
@@ -5,5 +5,5 @@ import model.musicvideo.MusicVideo
 
 interface YoutubeRepository {
 
-    fun searchMusicVideo(searchQuery: String): FlowResult<MusicVideo>
+    fun searchMusicVideo(searchQuery: String): FlowResult<MusicVideo?>
 }

--- a/domain/src/main/kotlin/repository/youtube/YoutubeRepository.kt
+++ b/domain/src/main/kotlin/repository/youtube/YoutubeRepository.kt
@@ -1,4 +1,4 @@
-package com.wepli.data.youtube.repository
+package repository.youtube
 
 import com.wepli.core.kotlin.flow.FlowResult
 import model.musicvideo.MusicVideo

--- a/feature/song/build.gradle.kts
+++ b/feature/song/build.gradle.kts
@@ -10,5 +10,4 @@ android {
 
 dependencies {
     implementation(libs.androidx.material3.window.size.clazz)
-    implementation(libs.youtube.player)
 }

--- a/feature/song/build.gradle.kts
+++ b/feature/song/build.gradle.kts
@@ -10,4 +10,5 @@ android {
 
 dependencies {
     implementation(libs.androidx.material3.window.size.clazz)
+    implementation(libs.youtube.player)
 }

--- a/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
+++ b/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
@@ -113,11 +113,13 @@ fun SongInfoScreen(
         ) {
             SongInfoLayout(song = song)
 
-            MusicVideoInfoLayout(
-                musicVideo = state.musicVideoState,
-                isExpanded = state.isMusicVideoExpanded,
-                onToggleExpanded = { sendAction(SongInfoIntent.ToggleMusicVideo) },
-            )
+            state.musicVideoState?.let { musicVideo ->
+                MusicVideoInfoLayout(
+                    musicVideo = musicVideo,
+                    isExpanded = state.isMusicVideoExpanded,
+                    onToggleExpanded = { sendAction(SongInfoIntent.ToggleMusicVideo) },
+                )
+            }
 
             SongDetailInfoLayout(
                 composers = song.composers,

--- a/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
+++ b/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -31,9 +32,15 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import appbar.ScrollableAppBar
 import appbar.WepliAppBar
+import com.pierfrancescosoffritti.androidyoutubeplayer.core.player.YouTubePlayer
+import com.pierfrancescosoffritti.androidyoutubeplayer.core.player.listeners.AbstractYouTubePlayerListener
+import com.pierfrancescosoffritti.androidyoutubeplayer.core.player.views.YouTubePlayerView
 import com.wepli.core.resources.R as CoreR
 import com.wepli.feature.song.info.component.album.AlbumInfoLayout
 import com.wepli.feature.song.info.component.album.ResponsiveAlbumGrid
@@ -120,7 +127,34 @@ fun SongInfoScreen(
 
 @Preview
 @Composable
+fun YoutubeVideoPlayer(
+    videoId: String = "",
+    lifecycleOwner: LifecycleOwner = LocalLifecycleOwner.current,
+    modifier: Modifier = Modifier
+) {
+    AndroidView(
+        modifier = modifier.fillMaxWidth(),
+        factory = {
+            YouTubePlayerView(context = it).apply { 
+                lifecycleOwner.lifecycle.addObserver(this)
+
+                addYouTubePlayerListener(object : AbstractYouTubePlayerListener() {
+                    override fun onReady(youTubePlayer: YouTubePlayer) {
+                        youTubePlayer.loadVideo(videoId, 0f)
+                    }
+                })
+            }
+        }
+    )
+}
+
+@Preview
+@Composable
 fun MusicVideoInfoLayout(isExpanded: Boolean = false) {
+    val videoSizeIcon = ImageVector.vectorResource(
+        if (isExpanded) CoreR.drawable.ic_arrow_minimize else CoreR.drawable.ic_arrow_expand
+    )
+
     Column {
         OneLineTitle(
             title = "뮤직비디오",
@@ -128,17 +162,27 @@ fun MusicVideoInfoLayout(isExpanded: Boolean = false) {
             modifier = Modifier.padding(vertical = 12.dp)
         )
 
+
+        if (isExpanded) {
+            YoutubeVideoPlayer(
+                videoId = "riWBCpP14ek",
+                modifier = Modifier.clip(RoundedCornerShape(16.dp))
+            )
+        }
+
         Row(
             modifier = Modifier.padding(top = 8.dp),
         ) {
-            AsyncImageWithPreview(
-                imageUrl = "https://image.bugsm.co.kr/artist/images/1000/803073/80307310_009.jpg?version=369360&d=20230515180027",
-                previewImage = painterResource(id = CoreR.drawable.img_placeholder_minnie),
-                imageOverrideSize = 52.dp,
-                modifier = Modifier
-                    .size(52.dp)
-                    .clip(RoundedCornerShape(8.dp))
-            )
+            if (isExpanded.not()) {
+                AsyncImageWithPreview(
+                    imageUrl = "https://image.bugsm.co.kr/artist/images/1000/803073/80307310_009.jpg?version=369360&d=20230515180027",
+                    previewImage = painterResource(id = CoreR.drawable.img_placeholder_minnie),
+                    imageOverrideSize = 52.dp,
+                    modifier = Modifier
+                        .size(52.dp)
+                        .clip(RoundedCornerShape(8.dp))
+                )
+            }
 
             WepliSpacer(horizontal = 12.dp)
 
@@ -161,7 +205,7 @@ fun MusicVideoInfoLayout(isExpanded: Boolean = false) {
             WepliSpacer(horizontal = 8.dp)
 
             Image(
-                imageVector = ImageVector.vectorResource(CoreR.drawable.ic_arrow_expand),
+                imageVector = videoSizeIcon,
                 contentDescription = null,
                 modifier = Modifier.size(24.dp)
             )

--- a/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
+++ b/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
@@ -152,7 +152,7 @@ fun MusicVideoInfoLayout(
 
         key("youtube_player") {
             YoutubeVideoPlayer(
-                videoId = "riWBCpP14ek",
+                videoId = "NbKH4iZqq1Y",
                 forcePause = !isExpanded,
                 modifier = Modifier
                     .clip(RoundedCornerShape(16.dp))

--- a/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
+++ b/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
@@ -142,11 +142,7 @@ fun MusicVideoInfoLayout(
     isExpanded: Boolean,
     onToggleExpanded: () -> Unit,
 ) {
-    val videoSizeIcon by remember(isExpanded) {
-        derivedStateOf {
-            if (isExpanded) CoreR.drawable.ic_arrow_minimize else CoreR.drawable.ic_arrow_expand
-        }
-    }
+    val videoSizeIcon = if (isExpanded) CoreR.drawable.ic_arrow_minimize else CoreR.drawable.ic_arrow_expand
 
     Column(
         modifier = Modifier.animateContentSize()

--- a/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
+++ b/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -22,8 +23,10 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -117,7 +120,7 @@ fun SongInfoScreen(
             SongInfoLayout(song = song)
 
             MusicVideoInfoLayout(
-                isExpanded = state.isMusicVideoExpanded,
+                state = state,
                 onToggleExpanded = { viewModel.processIntent(SongInfoIntent.ToggleMusicVideo) }
             )
 
@@ -147,7 +150,7 @@ fun YoutubeVideoPlayer(
 
     LaunchedEffect(isPause) {
         youTubePlayer?.let { player ->
-            if (isPause) player.pause() else player.play()
+            if (isPause) player.pause()
         }
     }
     
@@ -171,9 +174,10 @@ fun YoutubeVideoPlayer(
 @Preview
 @Composable
 fun MusicVideoInfoLayout(
-    isExpanded: Boolean = false,
+    state: SongInfoUiState = SongInfoUiState(),
     onToggleExpanded: () -> Unit = {}
 ) {
+    val isExpanded = state.isMusicVideoExpanded
     val videoSizeIcon = ImageVector.vectorResource(
         if (isExpanded) CoreR.drawable.ic_arrow_minimize else CoreR.drawable.ic_arrow_expand
     )
@@ -187,12 +191,17 @@ fun MusicVideoInfoLayout(
             modifier = Modifier.padding(vertical = 12.dp)
         )
 
-
-        if (isExpanded) {
+        key("youtube_player") {
             YoutubeVideoPlayer(
                 videoId = "riWBCpP14ek",
-                isPause = isExpanded.not(),
-                modifier = Modifier.clip(RoundedCornerShape(16.dp))
+                isPause = !isExpanded,
+                modifier = Modifier
+                    .clip(RoundedCornerShape(16.dp))
+                    .wrapContentHeight()
+                    .let {
+                        if (isExpanded) it
+                        else it.height(0.dp)
+                    }
             )
         }
 

--- a/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
+++ b/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
@@ -35,7 +35,6 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import appbar.ScrollableAppBar
@@ -50,6 +49,7 @@ import com.wepli.feature.song.info.mvi.SongInfoIntent
 import com.wepli.feature.song.info.mvi.SongInfoUiState
 import com.wepli.shared.feature.mock.songMockData
 import com.wepli.shared.feature.uimodel.album.AlbumUiData
+import com.wepli.shared.feature.uimodel.musicvideo.MusicVideoUiData
 import com.wepli.uimodel.music.SongUiData
 import common.WepliSpacer
 import custom.OneLineTitle
@@ -112,9 +112,10 @@ fun SongInfoScreen(
             SongInfoLayout(song = song)
 
             MusicVideoInfoLayout(
-                musicVideoState = state.musicVideoState,
+                musicVideo = state.musicVideoState,
                 isExpanded = state.isMusicVideoExpanded,
-                onToggleExpanded = { sendAction(SongInfoIntent.ToggleMusicVideo) }
+                onToggleExpanded = { sendAction(SongInfoIntent.ToggleMusicVideo) },
+                sendAction = sendAction
             )
 
             SongDetailInfoLayout(
@@ -133,9 +134,10 @@ fun SongInfoScreen(
 
 @Composable
 fun MusicVideoInfoLayout(
-    musicVideoState: SongInfoUiState.MusicVideoState,
+    musicVideo: MusicVideoUiData,
     isExpanded: Boolean,
     onToggleExpanded: () -> Unit,
+    sendAction: (SongInfoIntent) -> Unit = {},
 ) {
     val videoSizeIcon = ImageVector.vectorResource(
         if (isExpanded) CoreR.drawable.ic_arrow_minimize else CoreR.drawable.ic_arrow_expand
@@ -150,10 +152,13 @@ fun MusicVideoInfoLayout(
             modifier = Modifier.padding(vertical = 12.dp)
         )
 
-        key("youtube_player") {
+        key("youtube_player_${musicVideo.id}") {
             YoutubeVideoPlayer(
-                videoId = "NbKH4iZqq1Y",
+                videoId = musicVideo.id,
                 forcePause = !isExpanded,
+                onDurationReady = { duration ->
+                    sendAction(SongInfoIntent.UpdateMusicVideoDuration(duration))
+                },
                 modifier = Modifier
                     .clip(RoundedCornerShape(16.dp))
                     .wrapContentHeight()
@@ -169,7 +174,7 @@ fun MusicVideoInfoLayout(
         ) {
             if (isExpanded.not()) {
                 AsyncImageWithPreview(
-                    imageUrl = "https://image.bugsm.co.kr/artist/images/1000/803073/80307310_009.jpg?version=369360&d=20230515180027",
+                    imageUrl = musicVideo.thumbnail,
                     previewImage = painterResource(id = CoreR.drawable.img_placeholder_minnie),
                     imageOverrideSize = 52.dp,
                     modifier = Modifier
@@ -188,14 +193,14 @@ fun MusicVideoInfoLayout(
                     verticalArrangement = Arrangement.spacedBy(4.dp)
                 ) {
                     Text(
-                        text = "[Playlist]숲 공기\uD83C\uDF3F가득 마시며 일하기 |업무음악,공부음악,작업음악,집중할때듣는음악,독서음악 |",
+                        text = musicVideo.title,
                         style = WepliTheme.typo.body6,
                         color = WepliTheme.color.gray900,
                         maxLines = 2,
                         overflow = TextOverflow.Ellipsis,
                     )
                     Text(
-                        text = "02:48:58",
+                        text = musicVideo.playtime.toString(),
                         style = WepliTheme.typo.subTitle7,
                         color = WepliTheme.color.gray600
                     )

--- a/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
+++ b/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
@@ -156,33 +156,36 @@ fun MusicVideoInfoLayout(
             modifier = Modifier.padding(vertical = 12.dp)
         )
 
-        key("youtube_player_${musicVideo.id}") {
-            YoutubeVideoPlayer(
-                videoId = musicVideo.id,
-                forcePause = !isExpanded,
-                modifier = Modifier
-                    .clip(RoundedCornerShape(16.dp))
-                    .wrapContentHeight()
-                    .let {
-                        if (isExpanded) it
-                        else it.height(0.dp)
-                    }
-            )
-        }
+        YoutubeVideoPlayer(
+            videoId = musicVideo.id,
+            forcePause = !isExpanded,
+            modifier = Modifier
+                .clip(RoundedCornerShape(16.dp))
+                .wrapContentHeight()
+                .animateContentSize()
+                .let {
+                    if (isExpanded) it
+                    else it.height(0.dp)
+                }
+        )
 
         Row(
             modifier = Modifier.padding(top = 8.dp),
         ) {
-            if (isExpanded.not()) {
-                AsyncImageWithPreview(
-                    imageUrl = musicVideo.thumbnail,
-                    previewImage = painterResource(id = CoreR.drawable.img_placeholder_minnie),
-                    imageOverrideSize = 52.dp,
-                    modifier = Modifier
-                        .size(52.dp)
-                        .clip(RoundedCornerShape(8.dp))
-                )
+            AsyncImageWithPreview(
+                imageUrl = musicVideo.thumbnail,
+                previewImage = painterResource(id = CoreR.drawable.img_placeholder_minnie),
+                imageOverrideSize = 52.dp,
+                modifier = Modifier
+                    .clip(RoundedCornerShape(8.dp))
+                    .animateContentSize()
+                    .let {
+                        if (isExpanded) it.size(0.dp)
+                        else it.size(52.dp)
+                    }
+            )
 
+            if (isExpanded.not()) {
                 WepliSpacer(horizontal = 12.dp)
             }
 

--- a/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
+++ b/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
@@ -156,9 +157,6 @@ fun MusicVideoInfoLayout(
             YoutubeVideoPlayer(
                 videoId = musicVideo.id,
                 forcePause = !isExpanded,
-                onDurationReady = { duration ->
-                    sendAction(SongInfoIntent.UpdateMusicVideoDuration(duration))
-                },
                 modifier = Modifier
                     .clip(RoundedCornerShape(16.dp))
                     .wrapContentHeight()
@@ -200,7 +198,7 @@ fun MusicVideoInfoLayout(
                         overflow = TextOverflow.Ellipsis,
                     )
                     Text(
-                        text = musicVideo.formattedPlaytime,
+                        text = musicVideo.channelTitle,
                         style = WepliTheme.typo.subTitle7,
                         color = WepliTheme.color.gray600
                     )

--- a/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
+++ b/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
@@ -178,10 +178,7 @@ fun MusicVideoInfoLayout(
                 modifier = Modifier
                     .clip(RoundedCornerShape(8.dp))
                     .animateContentSize()
-                    .let {
-                        if (isExpanded) it.size(0.dp)
-                        else it.size(52.dp)
-                    }
+                    .size(if (isExpanded) 0.dp else 52.dp)
             )
 
             if (isExpanded.not()) {

--- a/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
+++ b/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
@@ -139,19 +139,15 @@ fun SongInfoScreen(
 @Composable
 fun YoutubeVideoPlayer(
     videoId: String = "",
-    isExpanded: Boolean = false,
+    isPause: Boolean = false,
     lifecycleOwner: LifecycleOwner = LocalLifecycleOwner.current,
     modifier: Modifier = Modifier
 ) {
     var youTubePlayer: YouTubePlayer? by remember { mutableStateOf(null) }
-    
-    LaunchedEffect(isExpanded) {
+
+    LaunchedEffect(isPause) {
         youTubePlayer?.let { player ->
-            if (isExpanded) {
-                player.play()
-            } else {
-                player.pause()
-            }
+            if (isPause) player.pause() else player.play()
         }
     }
     
@@ -195,7 +191,7 @@ fun MusicVideoInfoLayout(
         if (isExpanded) {
             YoutubeVideoPlayer(
                 videoId = "riWBCpP14ek",
-                isExpanded = isExpanded,
+                isPause = isExpanded.not(),
                 modifier = Modifier.clip(RoundedCornerShape(16.dp))
             )
         }

--- a/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
+++ b/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
@@ -206,7 +206,9 @@ fun MusicVideoInfoLayout(
                     Text(
                         text = musicVideo.channelTitle,
                         style = WepliTheme.typo.subTitle7,
-                        color = WepliTheme.color.gray600
+                        color = WepliTheme.color.gray600,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
                     )
                 }
 

--- a/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
+++ b/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
@@ -200,7 +200,7 @@ fun MusicVideoInfoLayout(
                         overflow = TextOverflow.Ellipsis,
                     )
                     Text(
-                        text = musicVideo.playtime.toString(),
+                        text = musicVideo.formattedPlaytime,
                         style = WepliTheme.typo.subTitle7,
                         color = WepliTheme.color.gray600
                     )

--- a/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
+++ b/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
@@ -44,6 +44,7 @@ import com.wepli.feature.song.info.mvi.SongInfoUiState
 import com.wepli.shared.feature.mock.songMockData
 import com.wepli.shared.feature.uimodel.album.AlbumUiData
 import com.wepli.uimodel.music.SongUiData
+import common.WepliSpacer
 import custom.OneLineTitle
 import image.AsyncImageWithPreview
 import org.orbitmvi.orbit.compose.collectAsState
@@ -101,6 +102,8 @@ fun SongInfoScreen(
         ) {
             SongInfoLayout(song = song)
 
+            MusicVideoInfoLayout()
+
             SongDetailInfoLayout(
                 composers = song.composers,
                 genres = song.genres
@@ -114,6 +117,58 @@ fun SongInfoScreen(
         }
     }
 }
+
+@Preview
+@Composable
+fun MusicVideoInfoLayout(isExpanded: Boolean = false) {
+    Column {
+        OneLineTitle(
+            title = "뮤직비디오",
+            showIcon = true,
+            modifier = Modifier.padding(vertical = 12.dp)
+        )
+
+        Row(
+            modifier = Modifier.padding(top = 8.dp),
+        ) {
+            AsyncImageWithPreview(
+                imageUrl = "https://image.bugsm.co.kr/artist/images/1000/803073/80307310_009.jpg?version=369360&d=20230515180027",
+                previewImage = painterResource(id = CoreR.drawable.img_placeholder_minnie),
+                imageOverrideSize = 52.dp,
+                modifier = Modifier
+                    .size(52.dp)
+                    .clip(RoundedCornerShape(8.dp))
+            )
+
+            WepliSpacer(horizontal = 12.dp)
+
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                Text(
+                    text = "[Playlist]숲 공기\uD83C\uDF3F가득 마시며 일하기 |업무음악,공부음악,작업음악,집중할때듣는음악,독서음악 |",
+                    style = WepliTheme.typo.body6,
+                    color = WepliTheme.color.gray900
+                )
+                Text(
+                    text = "02:48:58",
+                    style = WepliTheme.typo.subTitle7,
+                    color = WepliTheme.color.gray600
+                )
+            }
+
+            WepliSpacer(horizontal = 8.dp)
+
+            Image(
+                imageVector = ImageVector.vectorResource(CoreR.drawable.ic_arrow_expand),
+                contentDescription = null,
+                modifier = Modifier.size(24.dp)
+            )
+        }
+    }
+}
+
 
 @Composable
 fun SongInfoLayout(song: SongUiData) {
@@ -230,7 +285,7 @@ fun ArtistAlbumGrid(albums: List<AlbumUiData>) {
     }
 }
 
-@Preview
+@Preview(heightDp = 1000)
 @Composable
 fun SongInfoScreenPreview() {
     SongInfoScreen(state = SongInfoUiState(song = songMockData.random()), navOnBack = {})

--- a/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
+++ b/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
@@ -24,6 +24,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -136,18 +139,32 @@ fun SongInfoScreen(
 @Composable
 fun YoutubeVideoPlayer(
     videoId: String = "",
+    isExpanded: Boolean = false,
     lifecycleOwner: LifecycleOwner = LocalLifecycleOwner.current,
     modifier: Modifier = Modifier
 ) {
+    var youTubePlayer: YouTubePlayer? by remember { mutableStateOf(null) }
+    
+    LaunchedEffect(isExpanded) {
+        youTubePlayer?.let { player ->
+            if (isExpanded) {
+                player.play()
+            } else {
+                player.pause()
+            }
+        }
+    }
+    
     AndroidView(
         modifier = modifier.fillMaxWidth(),
         factory = {
-            YouTubePlayerView(context = it).apply { 
+            YouTubePlayerView(context = it).apply {
                 lifecycleOwner.lifecycle.addObserver(this)
 
                 addYouTubePlayerListener(object : AbstractYouTubePlayerListener() {
-                    override fun onReady(youTubePlayer: YouTubePlayer) {
-                        youTubePlayer.loadVideo(videoId, 0f)
+                    override fun onReady(player: YouTubePlayer) {
+                        youTubePlayer = player
+                        player.cueVideo(videoId, 0f)
                     }
                 })
             }
@@ -178,6 +195,7 @@ fun MusicVideoInfoLayout(
         if (isExpanded) {
             YoutubeVideoPlayer(
                 videoId = "riWBCpP14ek",
+                isExpanded = isExpanded,
                 modifier = Modifier.clip(RoundedCornerShape(16.dp))
             )
         }

--- a/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
+++ b/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import appbar.ScrollableAppBar
@@ -69,8 +70,8 @@ fun SongInfoScreenRoute(
 
     SongInfoScreen(
         state = state,
+        sendAction = { viewModel.processIntent(it) },
         navOnBack = navOnBack,
-        viewModel = viewModel
     )
 }
 
@@ -78,8 +79,8 @@ fun SongInfoScreenRoute(
 @Composable
 fun SongInfoScreen(
     state: SongInfoUiState,
+    sendAction: (SongInfoIntent) -> Unit,
     navOnBack: () -> Unit,
-    viewModel: SongInfoViewModel = hiltViewModel()
 ) {
     val scrollState = rememberScrollState()
     val song = state.song
@@ -110,8 +111,8 @@ fun SongInfoScreen(
             SongInfoLayout(song = song)
 
             MusicVideoInfoLayout(
-                state = state,
-                onToggleExpanded = { viewModel.processIntent(SongInfoIntent.ToggleMusicVideo) }
+                isExpanded = state.isMusicVideoExpanded,
+                onToggleExpanded = { sendAction(SongInfoIntent.ToggleMusicVideo) }
             )
 
             SongDetailInfoLayout(
@@ -128,14 +129,11 @@ fun SongInfoScreen(
     }
 }
 
-
-@Preview
 @Composable
 fun MusicVideoInfoLayout(
-    state: SongInfoUiState = SongInfoUiState(),
-    onToggleExpanded: () -> Unit = {}
+    isExpanded: Boolean,
+    onToggleExpanded: () -> Unit,
 ) {
-    val isExpanded = state.isMusicVideoExpanded
     val videoSizeIcon = ImageVector.vectorResource(
         if (isExpanded) CoreR.drawable.ic_arrow_minimize else CoreR.drawable.ic_arrow_expand
     )
@@ -334,6 +332,6 @@ fun SongInfoScreenPreview() {
     SongInfoScreen(
         state = SongInfoUiState(song = songMockData.random()),
         navOnBack = {},
-        viewModel = hiltViewModel()
+        sendAction = {},
     )
 }

--- a/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
+++ b/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
@@ -198,31 +198,35 @@ fun MusicVideoInfoLayout(
                 WepliSpacer(horizontal = 12.dp)
             }
 
-            Column(
-                modifier = Modifier.weight(1f),
-                verticalArrangement = Arrangement.spacedBy(4.dp)
+            Row(
+                modifier = Modifier.padding(top = if (isExpanded) 8.dp else 0.dp)
             ) {
-                Text(
-                    text = "[Playlist]숲 공기\uD83C\uDF3F가득 마시며 일하기 |업무음악,공부음악,작업음악,집중할때듣는음악,독서음악 |",
-                    style = WepliTheme.typo.body6,
-                    color = WepliTheme.color.gray900
-                )
-                Text(
-                    text = "02:48:58",
-                    style = WepliTheme.typo.subTitle7,
-                    color = WepliTheme.color.gray600
+                Column(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    Text(
+                        text = "[Playlist]숲 공기\uD83C\uDF3F가득 마시며 일하기 |업무음악,공부음악,작업음악,집중할때듣는음악,독서음악 |",
+                        style = WepliTheme.typo.body6,
+                        color = WepliTheme.color.gray900
+                    )
+                    Text(
+                        text = "02:48:58",
+                        style = WepliTheme.typo.subTitle7,
+                        color = WepliTheme.color.gray600
+                    )
+                }
+
+                WepliSpacer(horizontal = 8.dp)
+
+                Image(
+                    imageVector = videoSizeIcon,
+                    contentDescription = null,
+                    modifier = Modifier
+                        .size(20.dp)
+                        .clickable { onToggleExpanded() }
                 )
             }
-
-            WepliSpacer(horizontal = 8.dp)
-
-            Image(
-                imageVector = videoSizeIcon,
-                contentDescription = null,
-                modifier = Modifier
-                    .size(24.dp)
-                    .clickable { onToggleExpanded() }
-            )
         }
     }
 }

--- a/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
+++ b/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
@@ -23,27 +23,23 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.key
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import appbar.ScrollableAppBar
 import appbar.WepliAppBar
-import component.youtube.YoutubeVideoPlayer
-import com.wepli.core.resources.R as CoreR
+import com.wepli.feature.song.R
 import com.wepli.feature.song.info.component.album.AlbumInfoLayout
 import com.wepli.feature.song.info.component.album.ResponsiveAlbumGrid
 import com.wepli.feature.song.info.component.song.SimilarSongsLayout
@@ -55,10 +51,12 @@ import com.wepli.shared.feature.uimodel.album.AlbumUiData
 import com.wepli.shared.feature.uimodel.musicvideo.MusicVideoUiData
 import com.wepli.uimodel.music.SongUiData
 import common.WepliSpacer
+import component.youtube.YoutubeVideoPlayer
 import custom.OneLineTitle
 import image.AsyncImageWithPreview
 import org.orbitmvi.orbit.compose.collectAsState
 import theme.WepliTheme
+import com.wepli.core.resources.R as CoreR
 
 @Composable
 fun SongInfoScreenRoute(
@@ -148,7 +146,7 @@ fun MusicVideoInfoLayout(
         modifier = Modifier.animateContentSize()
     ) {
         OneLineTitle(
-            title = "뮤직비디오",
+            title = stringResource(R.string.song_info_music_video),
             showIcon = true,
             modifier = Modifier.padding(vertical = 12.dp)
         )
@@ -253,7 +251,7 @@ fun SongInfoLayout(song: SongUiData) {
         )
 
         Text(
-            text = "FLAC",
+            text = stringResource(R.string.song_info_flac),
             style = WepliTheme.typo.subTitle7,
             color = WepliTheme.color.gray600,
             modifier = Modifier.padding(top = 4.dp)
@@ -323,7 +321,7 @@ private fun LabeledIcon(
 fun ArtistAlbumGrid(albums: List<AlbumUiData>) {
     Column {
         OneLineTitle(
-            title = "이 가수의 다른 앨범",
+            title = stringResource(R.string.song_info_other_albums),
             showIcon = true,
             modifier = Modifier.padding(vertical = 12.dp)
         )

--- a/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
+++ b/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
@@ -23,8 +23,10 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -137,9 +139,11 @@ fun MusicVideoInfoLayout(
     isExpanded: Boolean,
     onToggleExpanded: () -> Unit,
 ) {
-    val videoSizeIcon = ImageVector.vectorResource(
-        if (isExpanded) CoreR.drawable.ic_arrow_minimize else CoreR.drawable.ic_arrow_expand
-    )
+    val videoSizeIcon by remember(isExpanded) {
+        derivedStateOf {
+            if (isExpanded) CoreR.drawable.ic_arrow_minimize else CoreR.drawable.ic_arrow_expand
+        }
+    }
 
     Column(
         modifier = Modifier.animateContentSize()
@@ -204,7 +208,7 @@ fun MusicVideoInfoLayout(
                 WepliSpacer(horizontal = 8.dp)
 
                 Image(
-                    imageVector = videoSizeIcon,
+                    imageVector = ImageVector.vectorResource(videoSizeIcon),
                     contentDescription = null,
                     modifier = Modifier
                         .size(20.dp)

--- a/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
+++ b/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
@@ -170,7 +170,9 @@ fun MusicVideoInfoLayout(
         )
 
         Row(
-            modifier = Modifier.padding(top = 8.dp),
+            modifier = Modifier
+                .padding(top = 8.dp)
+                .clickable { onToggleExpanded() },
         ) {
             AsyncImageWithPreview(
                 imageUrl = musicVideo.thumbnail,
@@ -217,9 +219,7 @@ fun MusicVideoInfoLayout(
                 Image(
                     imageVector = ImageVector.vectorResource(videoSizeIcon),
                     contentDescription = null,
-                    modifier = Modifier
-                        .size(20.dp)
-                        .clickable { onToggleExpanded() }
+                    modifier = Modifier.size(20.dp)
                 )
             }
         }

--- a/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
+++ b/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import appbar.ScrollableAppBar
@@ -191,37 +192,33 @@ fun MusicVideoInfoLayout(
                 WepliSpacer(horizontal = 12.dp)
             }
 
-            Row(
-                modifier = Modifier.padding(top = if (isExpanded) 8.dp else 0.dp)
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(4.dp)
             ) {
-                Column(
-                    modifier = Modifier.weight(1f),
-                    verticalArrangement = Arrangement.spacedBy(4.dp)
-                ) {
-                    Text(
-                        text = musicVideo.title,
-                        style = WepliTheme.typo.body6,
-                        color = WepliTheme.color.gray900,
-                        maxLines = 2,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                    Text(
-                        text = musicVideo.channelTitle,
-                        style = WepliTheme.typo.subTitle7,
-                        color = WepliTheme.color.gray600,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
-                    )
-                }
-
-                WepliSpacer(horizontal = 8.dp)
-
-                Image(
-                    imageVector = ImageVector.vectorResource(videoSizeIcon),
-                    contentDescription = null,
-                    modifier = Modifier.size(20.dp)
+                Text(
+                    text = musicVideo.title,
+                    style = WepliTheme.typo.body6,
+                    color = WepliTheme.color.gray900,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    text = musicVideo.channelTitle,
+                    style = WepliTheme.typo.subTitle7,
+                    color = WepliTheme.color.gray600,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
                 )
             }
+
+            WepliSpacer(horizontal = 8.dp)
+
+            Image(
+                imageVector = ImageVector.vectorResource(videoSizeIcon),
+                contentDescription = null,
+                modifier = Modifier.size(20.dp)
+            )
         }
     }
 }

--- a/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
+++ b/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
@@ -111,6 +112,7 @@ fun SongInfoScreen(
             SongInfoLayout(song = song)
 
             MusicVideoInfoLayout(
+                musicVideoState = state.musicVideoState,
                 isExpanded = state.isMusicVideoExpanded,
                 onToggleExpanded = { sendAction(SongInfoIntent.ToggleMusicVideo) }
             )
@@ -131,6 +133,7 @@ fun SongInfoScreen(
 
 @Composable
 fun MusicVideoInfoLayout(
+    musicVideoState: SongInfoUiState.MusicVideoState,
     isExpanded: Boolean,
     onToggleExpanded: () -> Unit,
 ) {
@@ -187,7 +190,9 @@ fun MusicVideoInfoLayout(
                     Text(
                         text = "[Playlist]숲 공기\uD83C\uDF3F가득 마시며 일하기 |업무음악,공부음악,작업음악,집중할때듣는음악,독서음악 |",
                         style = WepliTheme.typo.body6,
-                        color = WepliTheme.color.gray900
+                        color = WepliTheme.color.gray900,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
                     )
                     Text(
                         text = "02:48:58",

--- a/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
+++ b/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -23,13 +22,9 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -40,15 +35,10 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.viewinterop.AndroidView
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.compose.LocalLifecycleOwner
 import appbar.ScrollableAppBar
 import appbar.WepliAppBar
-import com.pierfrancescosoffritti.androidyoutubeplayer.core.player.YouTubePlayer
-import com.pierfrancescosoffritti.androidyoutubeplayer.core.player.listeners.AbstractYouTubePlayerListener
-import com.pierfrancescosoffritti.androidyoutubeplayer.core.player.views.YouTubePlayerView
+import component.youtube.YoutubeVideoPlayer
 import com.wepli.core.resources.R as CoreR
 import com.wepli.feature.song.info.component.album.AlbumInfoLayout
 import com.wepli.feature.song.info.component.album.ResponsiveAlbumGrid
@@ -138,38 +128,6 @@ fun SongInfoScreen(
     }
 }
 
-@Preview
-@Composable
-fun YoutubeVideoPlayer(
-    videoId: String = "",
-    isPause: Boolean = false,
-    lifecycleOwner: LifecycleOwner = LocalLifecycleOwner.current,
-    modifier: Modifier = Modifier
-) {
-    var youTubePlayer: YouTubePlayer? by remember { mutableStateOf(null) }
-
-    LaunchedEffect(isPause) {
-        youTubePlayer?.let { player ->
-            if (isPause) player.pause()
-        }
-    }
-    
-    AndroidView(
-        modifier = modifier.fillMaxWidth(),
-        factory = {
-            YouTubePlayerView(context = it).apply {
-                lifecycleOwner.lifecycle.addObserver(this)
-
-                addYouTubePlayerListener(object : AbstractYouTubePlayerListener() {
-                    override fun onReady(player: YouTubePlayer) {
-                        youTubePlayer = player
-                        player.cueVideo(videoId, 0f)
-                    }
-                })
-            }
-        }
-    )
-}
 
 @Preview
 @Composable
@@ -194,7 +152,7 @@ fun MusicVideoInfoLayout(
         key("youtube_player") {
             YoutubeVideoPlayer(
                 videoId = "riWBCpP14ek",
-                isPause = !isExpanded,
+                forcePause = !isExpanded,
                 modifier = Modifier
                     .clip(RoundedCornerShape(16.dp))
                     .wrapContentHeight()

--- a/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
+++ b/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
@@ -1,8 +1,10 @@
 package com.wepli.feature.song.info
 
 import androidx.annotation.DrawableRes
+import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -71,7 +73,8 @@ fun SongInfoScreenRoute(
 
     SongInfoScreen(
         state = state,
-        navOnBack = navOnBack
+        navOnBack = navOnBack,
+        viewModel = viewModel
     )
 }
 
@@ -79,7 +82,8 @@ fun SongInfoScreenRoute(
 @Composable
 fun SongInfoScreen(
     state: SongInfoUiState,
-    navOnBack: () -> Unit
+    navOnBack: () -> Unit,
+    viewModel: SongInfoViewModel = hiltViewModel()
 ) {
     val scrollState = rememberScrollState()
     val song = state.song
@@ -109,7 +113,10 @@ fun SongInfoScreen(
         ) {
             SongInfoLayout(song = song)
 
-            MusicVideoInfoLayout()
+            MusicVideoInfoLayout(
+                isExpanded = state.isMusicVideoExpanded,
+                onToggleExpanded = { viewModel.processIntent(SongInfoIntent.ToggleMusicVideo) }
+            )
 
             SongDetailInfoLayout(
                 composers = song.composers,
@@ -150,12 +157,17 @@ fun YoutubeVideoPlayer(
 
 @Preview
 @Composable
-fun MusicVideoInfoLayout(isExpanded: Boolean = false) {
+fun MusicVideoInfoLayout(
+    isExpanded: Boolean = false,
+    onToggleExpanded: () -> Unit = {}
+) {
     val videoSizeIcon = ImageVector.vectorResource(
         if (isExpanded) CoreR.drawable.ic_arrow_minimize else CoreR.drawable.ic_arrow_expand
     )
 
-    Column {
+    Column(
+        modifier = Modifier.animateContentSize()
+    ) {
         OneLineTitle(
             title = "뮤직비디오",
             showIcon = true,
@@ -182,9 +194,9 @@ fun MusicVideoInfoLayout(isExpanded: Boolean = false) {
                         .size(52.dp)
                         .clip(RoundedCornerShape(8.dp))
                 )
-            }
 
-            WepliSpacer(horizontal = 12.dp)
+                WepliSpacer(horizontal = 12.dp)
+            }
 
             Column(
                 modifier = Modifier.weight(1f),
@@ -207,7 +219,9 @@ fun MusicVideoInfoLayout(isExpanded: Boolean = false) {
             Image(
                 imageVector = videoSizeIcon,
                 contentDescription = null,
-                modifier = Modifier.size(24.dp)
+                modifier = Modifier
+                    .size(24.dp)
+                    .clickable { onToggleExpanded() }
             )
         }
     }
@@ -332,5 +346,9 @@ fun ArtistAlbumGrid(albums: List<AlbumUiData>) {
 @Preview(heightDp = 1000)
 @Composable
 fun SongInfoScreenPreview() {
-    SongInfoScreen(state = SongInfoUiState(song = songMockData.random()), navOnBack = {})
+    SongInfoScreen(
+        state = SongInfoUiState(song = songMockData.random()),
+        navOnBack = {},
+        viewModel = hiltViewModel()
+    )
 }

--- a/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
+++ b/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
@@ -116,7 +116,6 @@ fun SongInfoScreen(
                 musicVideo = state.musicVideoState,
                 isExpanded = state.isMusicVideoExpanded,
                 onToggleExpanded = { sendAction(SongInfoIntent.ToggleMusicVideo) },
-                sendAction = sendAction
             )
 
             SongDetailInfoLayout(
@@ -138,7 +137,6 @@ fun MusicVideoInfoLayout(
     musicVideo: MusicVideoUiData,
     isExpanded: Boolean,
     onToggleExpanded: () -> Unit,
-    sendAction: (SongInfoIntent) -> Unit = {},
 ) {
     val videoSizeIcon = ImageVector.vectorResource(
         if (isExpanded) CoreR.drawable.ic_arrow_minimize else CoreR.drawable.ic_arrow_expand

--- a/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
+++ b/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoScreen.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight

--- a/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoViewModel.kt
+++ b/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoViewModel.kt
@@ -65,7 +65,7 @@ class SongInfoViewModel @Inject constructor(
     }
 
     private fun getSimilarSongs(currentSongId: String, artistName: String, genre: String) = intent {
-        val searchQuery = "${artistName} ${genre}"
+        val searchQuery = "$artistName $genre"
 
         appleMusicRepository.searchMusics(searchQuery, 10)
             .flowOn(Dispatchers.IO)

--- a/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoViewModel.kt
+++ b/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoViewModel.kt
@@ -25,6 +25,7 @@ class SongInfoViewModel @Inject constructor(
     override fun processIntent(intent: SongInfoIntent) {
         when (intent) {
             is SongInfoIntent.Init -> init(intent.song)
+            SongInfoIntent.ToggleMusicVideo -> toggleMusicVideo()
         }
     }
 
@@ -98,5 +99,9 @@ class SongInfoViewModel @Inject constructor(
                     Log.e("SongInfoViewModel", it.message ?: "Error")
                 }
             )
+    }
+
+    private fun toggleMusicVideo() = intent {
+        updateState { copy(isMusicVideoExpanded = !isMusicVideoExpanded) }
     }
 }

--- a/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoViewModel.kt
+++ b/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoViewModel.kt
@@ -17,7 +17,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class SongInfoViewModel @Inject constructor(
-    private val appleMusicRepository: AppleMusicRepository
+    private val appleMusicRepository: AppleMusicRepository,
+    private val youtubeRepository: YoutubeRepository,
 ) : BaseMviViewModel<SongInfoUiState, SongInfoEffect, SongInfoIntent>(
     initialState = SongInfoUiState()
 ) {
@@ -39,6 +40,7 @@ class SongInfoViewModel @Inject constructor(
                         getAlbumById(it.albumId.orEmpty())
                         getSimilarSongs(song.id, it.artistName, it.genres.first())
                         getAlbumByArtist(it.artistId.orEmpty())
+                        getMusicVideo(it.title, it.artistName)
                     },
                     onFailure = {
                         Log.e("SongInfoViewModel", it.message ?: "Error")
@@ -94,6 +96,21 @@ class SongInfoViewModel @Inject constructor(
                     updateState {
                         copy(artistAlbums = it.map { AlbumUiData.fromDomain(it) })
                     }
+                },
+                onFailure = {
+                    Log.e("SongInfoViewModel", it.message ?: "Error")
+                }
+            )
+    }
+
+    private fun getMusicVideo(title: String, artistName: String) = launch {
+        val searchQuery = "$title $artistName Music Video"
+
+        youtubeRepository.searchMusicVideo(searchQuery = searchQuery)
+            .flowOn(Dispatchers.IO)
+            .collectResult(
+                onSuccess = {
+                    updateState { copy(musicVideoState = MusicVideoUiData.fromDomain(it)) }
                 },
                 onFailure = {
                     Log.e("SongInfoViewModel", it.message ?: "Error")

--- a/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoViewModel.kt
+++ b/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoViewModel.kt
@@ -47,7 +47,7 @@ class SongInfoViewModel @Inject constructor(
         }
     }
 
-    private suspend fun getAlbumById(albumId: String) = intent {
+    private fun getAlbumById(albumId: String) = intent {
         if (albumId.isEmpty()) return@intent
 
         appleMusicRepository.getAlbumById(albumId)
@@ -64,7 +64,7 @@ class SongInfoViewModel @Inject constructor(
             )
     }
 
-    private suspend fun getSimilarSongs(currentSongId: String, artistName: String, genre: String) = intent {
+    private fun getSimilarSongs(currentSongId: String, artistName: String, genre: String) = intent {
         val searchQuery = "${artistName} ${genre}"
 
         appleMusicRepository.searchMusics(searchQuery, 10)
@@ -84,7 +84,7 @@ class SongInfoViewModel @Inject constructor(
             )
     }
 
-    private suspend fun getAlbumByArtist(artistId: String) = intent {
+    private fun getAlbumByArtist(artistId: String) = intent {
         if (artistId.isEmpty()) return@intent
 
         appleMusicRepository.getAlbumsByArtist(artistId)

--- a/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoViewModel.kt
+++ b/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoViewModel.kt
@@ -111,8 +111,10 @@ class SongInfoViewModel @Inject constructor(
         youtubeRepository.searchMusicVideo(searchQuery = searchQuery)
             .flowOn(Dispatchers.IO)
             .collectResult(
-                onSuccess = {
-                    updateState { copy(musicVideoState = MusicVideoUiData.fromDomain(it)) }
+                onSuccess = { musicVideo ->
+                    if (musicVideo == null) return@collectResult
+
+                    updateState { copy(musicVideoState = MusicVideoUiData.fromDomain(musicVideo)) }
                 },
                 onFailure = {
                     Log.e("SongInfoViewModel", it.message ?: "Error")

--- a/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoViewModel.kt
+++ b/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoViewModel.kt
@@ -134,17 +134,4 @@ class SongInfoViewModel @Inject constructor(
             )
         }
     }
-
-    private fun formatDuration(seconds: Float): String {
-        val totalSeconds = seconds.toInt()
-        val hours = totalSeconds / 3600
-        val minutes = (totalSeconds % 3600) / 60
-        val remainingSeconds = totalSeconds % 60
-
-        return if (hours > 0) {
-            String.format("%d:%02d:%02d", hours, minutes, remainingSeconds)
-        } else {
-            String.format("%d:%02d", minutes, remainingSeconds)
-        }
-    }
 }

--- a/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoViewModel.kt
+++ b/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoViewModel.kt
@@ -102,6 +102,8 @@ class SongInfoViewModel @Inject constructor(
     }
 
     private fun toggleMusicVideo() = intent {
-        updateState { copy(isMusicVideoExpanded = !isMusicVideoExpanded) }
+        updateState { 
+            copy(isMusicVideoExpanded = !isMusicVideoExpanded)
+        }
     }
 }

--- a/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoViewModel.kt
+++ b/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoViewModel.kt
@@ -29,7 +29,6 @@ class SongInfoViewModel @Inject constructor(
         when (intent) {
             is SongInfoIntent.Init -> init(intent.song)
             SongInfoIntent.ToggleMusicVideo -> toggleMusicVideo()
-            is SongInfoIntent.UpdateMusicVideoDuration -> updateMusicVideoDuration(intent.duration)
         }
     }
 
@@ -124,14 +123,6 @@ class SongInfoViewModel @Inject constructor(
     private fun toggleMusicVideo() = intent {
         updateState { 
             copy(isMusicVideoExpanded = !isMusicVideoExpanded)
-        }
-    }
-
-    private fun updateMusicVideoDuration(duration: Float) = intent {
-        updateState {
-            copy(
-                musicVideoState = musicVideoState.copy(playtime = duration)
-            )
         }
     }
 }

--- a/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoViewModel.kt
+++ b/feature/song/src/main/java/com/wepli/feature/song/info/SongInfoViewModel.kt
@@ -8,11 +8,13 @@ import com.wepli.feature.song.info.mvi.SongInfoEffect
 import com.wepli.feature.song.info.mvi.SongInfoIntent
 import com.wepli.feature.song.info.mvi.SongInfoUiState
 import com.wepli.shared.feature.uimodel.album.AlbumUiData
+import com.wepli.shared.feature.uimodel.musicvideo.MusicVideoUiData
 import com.wepli.uimodel.music.SongUiData
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.flowOn
 import repository.applemusic.AppleMusicRepository
+import repository.youtube.YoutubeRepository
 import javax.inject.Inject
 
 @HiltViewModel
@@ -27,6 +29,7 @@ class SongInfoViewModel @Inject constructor(
         when (intent) {
             is SongInfoIntent.Init -> init(intent.song)
             SongInfoIntent.ToggleMusicVideo -> toggleMusicVideo()
+            is SongInfoIntent.UpdateMusicVideoDuration -> updateMusicVideoDuration(intent.duration)
         }
     }
 
@@ -121,6 +124,27 @@ class SongInfoViewModel @Inject constructor(
     private fun toggleMusicVideo() = intent {
         updateState { 
             copy(isMusicVideoExpanded = !isMusicVideoExpanded)
+        }
+    }
+
+    private fun updateMusicVideoDuration(duration: Float) = intent {
+        updateState {
+            copy(
+                musicVideoState = musicVideoState.copy(playtime = duration)
+            )
+        }
+    }
+
+    private fun formatDuration(seconds: Float): String {
+        val totalSeconds = seconds.toInt()
+        val hours = totalSeconds / 3600
+        val minutes = (totalSeconds % 3600) / 60
+        val remainingSeconds = totalSeconds % 60
+
+        return if (hours > 0) {
+            String.format("%d:%02d:%02d", hours, minutes, remainingSeconds)
+        } else {
+            String.format("%d:%02d", minutes, remainingSeconds)
         }
     }
 }

--- a/feature/song/src/main/java/com/wepli/feature/song/info/mvi/SongInfoMvi.kt
+++ b/feature/song/src/main/java/com/wepli/feature/song/info/mvi/SongInfoMvi.kt
@@ -9,11 +9,20 @@ import model.album.Album
 
 data class SongInfoUiState(
     val song: SongUiData = SongUiData(),
+    val musicVideoState: MusicVideoState = MusicVideoState(),
     val artistAlbums: List<AlbumUiData> = emptyList(),
     val album: AlbumUiData = AlbumUiData(),
     val similarSongs: List<SongUiData> = emptyList(),
     val isMusicVideoExpanded: Boolean = false,
-) : UiState
+) : UiState {
+
+    data class MusicVideoState(
+        val title: String = "",
+        val playtime: String = "",
+        val videoUrl: String = "",
+        val videoThumbnail: String = "",
+    )
+}
 
 interface SongInfoEffect : SideEffect
 

--- a/feature/song/src/main/java/com/wepli/feature/song/info/mvi/SongInfoMvi.kt
+++ b/feature/song/src/main/java/com/wepli/feature/song/info/mvi/SongInfoMvi.kt
@@ -10,7 +10,7 @@ import model.album.Album
 
 data class SongInfoUiState(
     val song: SongUiData = SongUiData(),
-    val musicVideoState: MusicVideoUiData = MusicVideoUiData(),
+    val musicVideoState: MusicVideoUiData? = null,
     val artistAlbums: List<AlbumUiData> = emptyList(),
     val album: AlbumUiData = AlbumUiData(),
     val similarSongs: List<SongUiData> = emptyList(),

--- a/feature/song/src/main/java/com/wepli/feature/song/info/mvi/SongInfoMvi.kt
+++ b/feature/song/src/main/java/com/wepli/feature/song/info/mvi/SongInfoMvi.kt
@@ -11,11 +11,13 @@ data class SongInfoUiState(
     val song: SongUiData = SongUiData(),
     val artistAlbums: List<AlbumUiData> = emptyList(),
     val album: AlbumUiData = AlbumUiData(),
-    val similarSongs: List<SongUiData> = emptyList()
+    val similarSongs: List<SongUiData> = emptyList(),
+    val isMusicVideoExpanded: Boolean = false
 ) : UiState
 
 interface SongInfoEffect : SideEffect
 
 interface SongInfoIntent : Intent {
     data class Init(val song: SongUiData) : SongInfoIntent
+    object ToggleMusicVideo : SongInfoIntent
 }

--- a/feature/song/src/main/java/com/wepli/feature/song/info/mvi/SongInfoMvi.kt
+++ b/feature/song/src/main/java/com/wepli/feature/song/info/mvi/SongInfoMvi.kt
@@ -12,7 +12,7 @@ data class SongInfoUiState(
     val artistAlbums: List<AlbumUiData> = emptyList(),
     val album: AlbumUiData = AlbumUiData(),
     val similarSongs: List<SongUiData> = emptyList(),
-    val isMusicVideoExpanded: Boolean = false
+    val isMusicVideoExpanded: Boolean = false,
 ) : UiState
 
 interface SongInfoEffect : SideEffect

--- a/feature/song/src/main/java/com/wepli/feature/song/info/mvi/SongInfoMvi.kt
+++ b/feature/song/src/main/java/com/wepli/feature/song/info/mvi/SongInfoMvi.kt
@@ -4,29 +4,23 @@ import base.Intent
 import base.SideEffect
 import base.UiState
 import com.wepli.shared.feature.uimodel.album.AlbumUiData
+import com.wepli.shared.feature.uimodel.musicvideo.MusicVideoUiData
 import com.wepli.uimodel.music.SongUiData
 import model.album.Album
 
 data class SongInfoUiState(
     val song: SongUiData = SongUiData(),
-    val musicVideoState: MusicVideoState = MusicVideoState(),
+    val musicVideoState: MusicVideoUiData = MusicVideoUiData(),
     val artistAlbums: List<AlbumUiData> = emptyList(),
     val album: AlbumUiData = AlbumUiData(),
     val similarSongs: List<SongUiData> = emptyList(),
     val isMusicVideoExpanded: Boolean = false,
-) : UiState {
-
-    data class MusicVideoState(
-        val title: String = "",
-        val playtime: String = "",
-        val videoUrl: String = "",
-        val videoThumbnail: String = "",
-    )
-}
+) : UiState
 
 interface SongInfoEffect : SideEffect
 
 interface SongInfoIntent : Intent {
     data class Init(val song: SongUiData) : SongInfoIntent
-    object ToggleMusicVideo : SongInfoIntent
+    data object ToggleMusicVideo : SongInfoIntent
+    data class UpdateMusicVideoDuration(val duration: Float) : SongInfoIntent
 }

--- a/feature/song/src/main/java/com/wepli/feature/song/info/mvi/SongInfoMvi.kt
+++ b/feature/song/src/main/java/com/wepli/feature/song/info/mvi/SongInfoMvi.kt
@@ -22,5 +22,4 @@ interface SongInfoEffect : SideEffect
 interface SongInfoIntent : Intent {
     data class Init(val song: SongUiData) : SongInfoIntent
     data object ToggleMusicVideo : SongInfoIntent
-    data class UpdateMusicVideoDuration(val duration: Float) : SongInfoIntent
 }

--- a/feature/song/src/main/res/values/strings.xml
+++ b/feature/song/src/main/res/values/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="song_info_music_video">뮤직비디오</string>
+    <string name="song_info_other_albums">이 가수의 다른 앨범</string>
+    <string name="song_info_flac">FLAC</string>
+</resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -67,6 +67,7 @@ junitKtx = "1.2.1"
 haze = "1.5.2"
 material3WindowSizeClassAndroid = "1.3.1"
 jsonTree = "2.5.0"
+youtube-player = "12.1.2"
 
 # Sns
 facebook-android-sdk = "18.0.2"
@@ -160,7 +161,7 @@ gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
 blur-haze = { group = "dev.chrisbanes.haze", name = "haze", version.ref = "haze" }
 blur-haze-materials = { group = "dev.chrisbanes.haze", name = "haze-materials", version.ref = "haze" }
 json-tree = { group = "com.sebastianneubauer.jsontree", name = "jsontree", version.ref = "jsonTree" }
-
+youtube-player = { group = "com.pierfrancescosoffritti.androidyoutubeplayer", name = "core", version.ref = "youtube-player"}
 
 # sns
 facebook-android-sdk = { group = "com.facebook.android", name = "facebook-android-sdk", version.ref = "facebook-android-sdk" }

--- a/shared/feature/src/main/java/com/wepli/shared/feature/uimodel/musicvideo/MusicVideoUiData.kt
+++ b/shared/feature/src/main/java/com/wepli/shared/feature/uimodel/musicvideo/MusicVideoUiData.kt
@@ -9,32 +9,15 @@ import model.musicvideo.MusicVideo
 data class MusicVideoUiData(
     val id: String = "",
     val title: String = "",
-    val playtime: Float = 0f,
+    val channelTitle: String = "",
     val thumbnail: String = "",
 ) : UiModel {
-
-    val formattedPlaytime: String
-        get() = formatDuration(playtime)
-
-    private fun formatDuration(seconds: Float): String {
-        val totalSeconds = seconds.toInt()
-        val hours = totalSeconds / 3600
-        val minutes = (totalSeconds % 3600) / 60
-        val remainingSeconds = totalSeconds % 60
-
-        return if (hours > 0) {
-            String.format("%d:%02d:%02d", hours, minutes, remainingSeconds)
-        } else {
-            String.format("%d:%02d", minutes, remainingSeconds)
-        }
-    }
-
     companion object : UiModelMapper<MusicVideo, MusicVideoUiData> {
         override fun fromDomain(domainModel: MusicVideo): MusicVideoUiData {
             return MusicVideoUiData(
                 id = domainModel.id,
                 title = domainModel.title,
-                playtime = domainModel.playtime,
+                channelTitle = domainModel.channelTitle,
                 thumbnail = domainModel.thumbnail
             )
         }

--- a/shared/feature/src/main/java/com/wepli/shared/feature/uimodel/musicvideo/MusicVideoUiData.kt
+++ b/shared/feature/src/main/java/com/wepli/shared/feature/uimodel/musicvideo/MusicVideoUiData.kt
@@ -12,6 +12,23 @@ data class MusicVideoUiData(
     val playtime: Float = 0f,
     val thumbnail: String = "",
 ) : UiModel {
+
+    val formattedPlaytime: String
+        get() = formatDuration(playtime)
+
+    private fun formatDuration(seconds: Float): String {
+        val totalSeconds = seconds.toInt()
+        val hours = totalSeconds / 3600
+        val minutes = (totalSeconds % 3600) / 60
+        val remainingSeconds = totalSeconds % 60
+
+        return if (hours > 0) {
+            String.format("%d:%02d:%02d", hours, minutes, remainingSeconds)
+        } else {
+            String.format("%d:%02d", minutes, remainingSeconds)
+        }
+    }
+
     companion object : UiModelMapper<MusicVideo, MusicVideoUiData> {
         override fun fromDomain(domainModel: MusicVideo): MusicVideoUiData {
             return MusicVideoUiData(

--- a/shared/feature/src/main/java/com/wepli/shared/feature/uimodel/musicvideo/MusicVideoUiData.kt
+++ b/shared/feature/src/main/java/com/wepli/shared/feature/uimodel/musicvideo/MusicVideoUiData.kt
@@ -1,0 +1,25 @@
+package com.wepli.shared.feature.uimodel.musicvideo
+
+import com.wepli.shared.feature.common.UiModel
+import com.wepli.shared.feature.common.UiModelMapper
+import kotlinx.parcelize.Parcelize
+import model.musicvideo.MusicVideo
+
+@Parcelize
+data class MusicVideoUiData(
+    val id: String = "",
+    val title: String = "",
+    val playtime: Float = 0f,
+    val thumbnail: String = "",
+) : UiModel {
+    companion object : UiModelMapper<MusicVideo, MusicVideoUiData> {
+        override fun fromDomain(domainModel: MusicVideo): MusicVideoUiData {
+            return MusicVideoUiData(
+                id = domainModel.id,
+                title = domainModel.title,
+                playtime = domainModel.playtime,
+                thumbnail = domainModel.thumbnail
+            )
+        }
+    }
+}


### PR DESCRIPTION
## 🔮 PR 요약

### 🖥️ 변경사항
- 노래 정보 화면에 뮤직 비디오 (Youtube) 추가
- "제목 가수 Music Video"의 형식으로 Youtube Search API를 이용하여 뮤비 검색

<br>

**유튜브 영상 생명주기 처리**

1. 아래 케이스에 대해 영상이 중지되도록 처리
   - 영상 정보가 접힌 상태일 때
   - 앱이 백그라운드로 전환 되었을 때

2. 영상 로드 최적화
```kotlin
if (isExpanded) {
    YoutubeVideoPlayer(/*...*/)
}
```
   - if문으로 isExpand 상태일 때만 영상을 추가하도록 하니 재구성 될 떄마다 영상이 재로드됨
  
```kotlin
        YoutubeVideoPlayer(
            videoId = musicVideo.id,
            forcePause = !isExpanded,
            modifier = Modifier
                .clip(RoundedCornerShape(16.dp))
                .wrapContentHeight()
                .animateContentSize()
                .let {
                    if (isExpanded) it
                    else it.height(0.dp)
                }
        )
```
   - key() 내부에서 조건부 렌더링을 하면 key의 이점을 제대로 활용하지 못함
   - key()를 제거하고 YoutubeVideoPlayer 자체가 videoId 변경을 처리하도록 하며, animateContentSize()를 활용

<br>

### 🌌 PR 포인트
- -

<br>

### 📸 스크린샷

| 뮤직비디오 | 생명주기 처리 |
|----------|-------------|
| ![Screen_Recording_20250714_001550_WePLi](https://github.com/user-attachments/assets/d14b7815-a83c-46be-a3d4-4b12f2ede2c3) | ![Screen_Recording_20250714_001629_WePLi](https://github.com/user-attachments/assets/552c479e-15fa-4ba4-ac99-647aa64cfc92) |

<br>

### 📮 관련 이슈

**노래 재생 시간 조회 이슈**
- Youtube Search API에선 재생 시간 정보를 제공하지 않음
- 재생 시간을 조회하려면 Video API를 사용해야함
   - 다만, 특정 노래에 대한 뮤직비디오 id를 모르니 Search API 사용은 필수
- 즉, 재생 시간 정보를 얻기 위해선 2번의 API를 호출해야하므로 재생 시간 대신 채널 이름을 출력하도록 수정